### PR TITLE
Add additional support for pragma VRF

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,6 @@ jobs:
             market,
             obstacles,
             combat,
-            game_entropy,
             game_snapshot,
           ]
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,6 @@ contracts/beasts/target/CACHEDIR.TAG
 keys
 account
 loot-survivor.pem
-contracts/game_entropy/target/CACHEDIR.TAG
-contracts/game_entropy/target/dev/game_entropy.sierra
 
 scripts/stress_test.py
 .env

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -4,7 +4,6 @@ members = [
     "contracts/beasts",
     "contracts/combat",
     "contracts/game",
-    "contracts/game_entropy",
     "contracts/game_snapshot",
     "contracts/loot",
     "contracts/lords",

--- a/contracts/adventurer/src/adventurer.cairo
+++ b/contracts/adventurer/src/adventurer.cairo
@@ -1380,12 +1380,11 @@ impl ImplAdventurer of IAdventurer {
     }
 
     fn get_randomness(
-        self: Adventurer, adventurer_entropy: u128, game_entropy: felt252
+        self: Adventurer, adventurer_entropy: u128
     ) -> (u128, u128) {
         let mut hash_span = ArrayTrait::<felt252>::new();
         hash_span.append(self.xp.into());
         hash_span.append(adventurer_entropy.into());
-        hash_span.append(game_entropy);
 
         let poseidon = poseidon_hash_span(hash_span.span());
         let (d, r) = integer::U256DivRem::div_rem(

--- a/contracts/game/src/game/constants.cairo
+++ b/contracts/game/src/game/constants.cairo
@@ -36,14 +36,13 @@ mod messages {
     const GAME_ALREADY_STARTED: felt252 = 'game already started';
     const STARTING_ENTROPY_IS_VALID: felt252 = 'starting entropy is valid';
     const VALID_BLOCK_HASH_UNAVAILABLE: felt252 = 'valid hash not yet available';
-    const START_ENTROPY_NOT_SET: felt252 = 'starting entropy not set';
+    const ADVENTURER_ENTROPY_NOT_SET: felt252 = 'adventurer entropy not set';
 }
 
 // TODO: Update for mainnet
 const BLOCKS_IN_A_WEEK: u64 = 1000;
 const COST_TO_PLAY: u128 = 25000000000000000000;
 const NUM_STARTING_STATS: u8 = 9;
-const STARTING_GAME_ENTROPY_ROTATION_INTERVAL: u8 = 6;
 const MINIMUM_DAMAGE_FROM_BEASTS: u8 = 2;
 const MAINNET_REVEAL_DELAY_BLOCKS: u8 = 11;
 

--- a/contracts/game/src/game/interfaces.cairo
+++ b/contracts/game/src/game/interfaces.cairo
@@ -58,35 +58,35 @@ trait IGame<TContractState> {
     fn get_gold(self: @TContractState, adventurer_id: felt252) -> u16;
     fn get_stat_upgrades_available(self: @TContractState, adventurer_id: felt252) -> u8;
 
-    // adventurer stats (includes boost)
-    fn get_stats(self: @TContractState, adventurer_id: felt252) -> Stats;
-    fn get_strength(self: @TContractState, adventurer_id: felt252) -> u8;
-    fn get_dexterity(self: @TContractState, adventurer_id: felt252) -> u8;
-    fn get_vitality(self: @TContractState, adventurer_id: felt252) -> u8;
-    fn get_intelligence(self: @TContractState, adventurer_id: felt252) -> u8;
-    fn get_wisdom(self: @TContractState, adventurer_id: felt252) -> u8;
-    fn get_charisma(self: @TContractState, adventurer_id: felt252) -> u8;
+    // // adventurer stats (includes boost)
+    // fn get_stats(self: @TContractState, adventurer_id: felt252) -> Stats;
+    // fn get_strength(self: @TContractState, adventurer_id: felt252) -> u8;
+    // fn get_dexterity(self: @TContractState, adventurer_id: felt252) -> u8;
+    // fn get_vitality(self: @TContractState, adventurer_id: felt252) -> u8;
+    // fn get_intelligence(self: @TContractState, adventurer_id: felt252) -> u8;
+    // fn get_wisdom(self: @TContractState, adventurer_id: felt252) -> u8;
+    // fn get_charisma(self: @TContractState, adventurer_id: felt252) -> u8;
 
-    // item details
-    fn get_equipped_items(self: @TContractState, adventurer_id: felt252) -> Array<ItemPrimitive>;
-    fn get_equipped_weapon(self: @TContractState, adventurer_id: felt252) -> ItemPrimitive;
-    fn get_equipped_chest(self: @TContractState, adventurer_id: felt252) -> ItemPrimitive;
-    fn get_equipped_head(self: @TContractState, adventurer_id: felt252) -> ItemPrimitive;
-    fn get_equipped_waist(self: @TContractState, adventurer_id: felt252) -> ItemPrimitive;
-    fn get_equipped_foot(self: @TContractState, adventurer_id: felt252) -> ItemPrimitive;
-    fn get_equipped_hand(self: @TContractState, adventurer_id: felt252) -> ItemPrimitive;
-    fn get_equipped_necklace(self: @TContractState, adventurer_id: felt252) -> ItemPrimitive;
-    fn get_equipped_ring(self: @TContractState, adventurer_id: felt252) -> ItemPrimitive;
+    // // item details
+    // fn get_equipped_items(self: @TContractState, adventurer_id: felt252) -> Array<ItemPrimitive>;
+    // fn get_equipped_weapon(self: @TContractState, adventurer_id: felt252) -> ItemPrimitive;
+    // fn get_equipped_chest(self: @TContractState, adventurer_id: felt252) -> ItemPrimitive;
+    // fn get_equipped_head(self: @TContractState, adventurer_id: felt252) -> ItemPrimitive;
+    // fn get_equipped_waist(self: @TContractState, adventurer_id: felt252) -> ItemPrimitive;
+    // fn get_equipped_foot(self: @TContractState, adventurer_id: felt252) -> ItemPrimitive;
+    // fn get_equipped_hand(self: @TContractState, adventurer_id: felt252) -> ItemPrimitive;
+    // fn get_equipped_necklace(self: @TContractState, adventurer_id: felt252) -> ItemPrimitive;
+    // fn get_equipped_ring(self: @TContractState, adventurer_id: felt252) -> ItemPrimitive;
 
-    // item stats
-    fn get_weapon_greatness(self: @TContractState, adventurer_id: felt252) -> u8;
-    fn get_chest_greatness(self: @TContractState, adventurer_id: felt252) -> u8;
-    fn get_head_greatness(self: @TContractState, adventurer_id: felt252) -> u8;
-    fn get_waist_greatness(self: @TContractState, adventurer_id: felt252) -> u8;
-    fn get_foot_greatness(self: @TContractState, adventurer_id: felt252) -> u8;
-    fn get_hand_greatness(self: @TContractState, adventurer_id: felt252) -> u8;
-    fn get_necklace_greatness(self: @TContractState, adventurer_id: felt252) -> u8;
-    fn get_ring_greatness(self: @TContractState, adventurer_id: felt252) -> u8;
+    // // item stats
+    // fn get_weapon_greatness(self: @TContractState, adventurer_id: felt252) -> u8;
+    // fn get_chest_greatness(self: @TContractState, adventurer_id: felt252) -> u8;
+    // fn get_head_greatness(self: @TContractState, adventurer_id: felt252) -> u8;
+    // fn get_waist_greatness(self: @TContractState, adventurer_id: felt252) -> u8;
+    // fn get_foot_greatness(self: @TContractState, adventurer_id: felt252) -> u8;
+    // fn get_hand_greatness(self: @TContractState, adventurer_id: felt252) -> u8;
+    // fn get_necklace_greatness(self: @TContractState, adventurer_id: felt252) -> u8;
+    // fn get_ring_greatness(self: @TContractState, adventurer_id: felt252) -> u8;
 
     // bag and specials
     fn get_bag(self: @TContractState, adventurer_id: felt252) -> Bag;
@@ -94,35 +94,35 @@ trait IGame<TContractState> {
         self: @TContractState, adventurer_id: felt252, storage_index: u8
     ) -> ItemSpecialsStorage;
 
-    // item details
-    fn get_weapon_specials(self: @TContractState, adventurer_id: felt252) -> ItemSpecials;
-    fn get_chest_specials(self: @TContractState, adventurer_id: felt252) -> ItemSpecials;
-    fn get_head_specials(self: @TContractState, adventurer_id: felt252) -> ItemSpecials;
-    fn get_waist_specials(self: @TContractState, adventurer_id: felt252) -> ItemSpecials;
-    fn get_foot_specials(self: @TContractState, adventurer_id: felt252) -> ItemSpecials;
-    fn get_hand_specials(self: @TContractState, adventurer_id: felt252) -> ItemSpecials;
-    fn get_necklace_specials(self: @TContractState, adventurer_id: felt252) -> ItemSpecials;
-    fn get_ring_specials(self: @TContractState, adventurer_id: felt252) -> ItemSpecials;
+    // // item details
+    // fn get_weapon_specials(self: @TContractState, adventurer_id: felt252) -> ItemSpecials;
+    // fn get_chest_specials(self: @TContractState, adventurer_id: felt252) -> ItemSpecials;
+    // fn get_head_specials(self: @TContractState, adventurer_id: felt252) -> ItemSpecials;
+    // fn get_waist_specials(self: @TContractState, adventurer_id: felt252) -> ItemSpecials;
+    // fn get_foot_specials(self: @TContractState, adventurer_id: felt252) -> ItemSpecials;
+    // fn get_hand_specials(self: @TContractState, adventurer_id: felt252) -> ItemSpecials;
+    // fn get_necklace_specials(self: @TContractState, adventurer_id: felt252) -> ItemSpecials;
+    // fn get_ring_specials(self: @TContractState, adventurer_id: felt252) -> ItemSpecials;
 
-    // market details
+    // // market details
     fn get_items_on_market(self: @TContractState, adventurer_id: felt252) -> Array<u8>;
-    fn get_items_on_market_by_slot(
-        self: @TContractState, adventurer_id: felt252, slot: u8
-    ) -> Array<u8>;
-    fn get_items_on_market_by_tier(
-        self: @TContractState, adventurer_id: felt252, tier: u8
-    ) -> Array<u8>;
-    fn get_potion_price(self: @TContractState, adventurer_id: felt252) -> u16;
-    fn get_item_price(self: @TContractState, adventurer_id: felt252, item_id: u8) -> u16;
+    // fn get_items_on_market_by_slot(
+    //     self: @TContractState, adventurer_id: felt252, slot: u8
+    // ) -> Array<u8>;
+    // fn get_items_on_market_by_tier(
+    //     self: @TContractState, adventurer_id: felt252, tier: u8
+    // ) -> Array<u8>;
+    // fn get_potion_price(self: @TContractState, adventurer_id: felt252) -> u16;
+    // fn get_item_price(self: @TContractState, adventurer_id: felt252, item_id: u8) -> u16;
 
-    // adventurer stats (no boosts)
-    fn get_base_stats(self: @TContractState, adventurer_id: felt252) -> Stats;
-    fn get_base_strength(self: @TContractState, adventurer_id: felt252) -> u8;
-    fn get_base_dexterity(self: @TContractState, adventurer_id: felt252) -> u8;
-    fn get_base_vitality(self: @TContractState, adventurer_id: felt252) -> u8;
-    fn get_base_intelligence(self: @TContractState, adventurer_id: felt252) -> u8;
-    fn get_base_wisdom(self: @TContractState, adventurer_id: felt252) -> u8;
-    fn get_base_charisma(self: @TContractState, adventurer_id: felt252) -> u8;
+    // // adventurer stats (no boosts)
+    // fn get_base_stats(self: @TContractState, adventurer_id: felt252) -> Stats;
+    // fn get_base_strength(self: @TContractState, adventurer_id: felt252) -> u8;
+    // fn get_base_dexterity(self: @TContractState, adventurer_id: felt252) -> u8;
+    // fn get_base_vitality(self: @TContractState, adventurer_id: felt252) -> u8;
+    // fn get_base_intelligence(self: @TContractState, adventurer_id: felt252) -> u8;
+    // fn get_base_wisdom(self: @TContractState, adventurer_id: felt252) -> u8;
+    // fn get_base_charisma(self: @TContractState, adventurer_id: felt252) -> u8;
 
     // beast details
     fn get_attacking_beast(self: @TContractState, adventurer_id: felt252) -> Beast;
@@ -131,25 +131,25 @@ trait IGame<TContractState> {
     fn get_beast_tier(self: @TContractState, beast_id: u8) -> u8;
 
     // game settings
-    fn starting_gold(self: @TContractState) -> u16;
-    fn starting_health(self: @TContractState) -> u16;
-    fn base_potion_price(self: @TContractState) -> u16;
-    fn potion_health_amount(self: @TContractState) -> u16;
-    fn minimum_potion_price(self: @TContractState) -> u16;
-    fn charisma_potion_discount(self: @TContractState) -> u16;
-    fn items_per_stat_upgrade(self: @TContractState) -> u8;
-    fn item_tier_price_multiplier(self: @TContractState) -> u16;
-    fn charisma_item_discount(self: @TContractState) -> u16;
-    fn minimum_item_price(self: @TContractState) -> u16;
-    fn minimum_damage_to_beasts(self: @TContractState) -> u8;
-    fn minimum_damage_from_beasts(self: @TContractState) -> u8;
-    fn minimum_damage_from_obstacles(self: @TContractState) -> u8;
-    fn obstacle_critical_hit_chance(self: @TContractState) -> u8;
-    fn stat_upgrades_per_level(self: @TContractState) -> u8;
-    fn beast_special_name_unlock_level(self: @TContractState) -> u16;
-    fn item_xp_multiplier_beasts(self: @TContractState) -> u16;
-    fn item_xp_multiplier_obstacles(self: @TContractState) -> u16;
-    fn strength_bonus_damage(self: @TContractState) -> u8;
+    // fn starting_gold(self: @TContractState) -> u16;
+    // fn starting_health(self: @TContractState) -> u16;
+    // fn base_potion_price(self: @TContractState) -> u16;
+    // fn potion_health_amount(self: @TContractState) -> u16;
+    // fn minimum_potion_price(self: @TContractState) -> u16;
+    // fn charisma_potion_discount(self: @TContractState) -> u16;
+    // fn items_per_stat_upgrade(self: @TContractState) -> u8;
+    // fn item_tier_price_multiplier(self: @TContractState) -> u16;
+    // fn charisma_item_discount(self: @TContractState) -> u16;
+    // fn minimum_item_price(self: @TContractState) -> u16;
+    // fn minimum_damage_to_beasts(self: @TContractState) -> u8;
+    // fn minimum_damage_from_beasts(self: @TContractState) -> u8;
+    // fn minimum_damage_from_obstacles(self: @TContractState) -> u8;
+    // fn obstacle_critical_hit_chance(self: @TContractState) -> u8;
+    // fn stat_upgrades_per_level(self: @TContractState) -> u8;
+    // fn beast_special_name_unlock_level(self: @TContractState) -> u16;
+    // fn item_xp_multiplier_beasts(self: @TContractState) -> u16;
+    // fn item_xp_multiplier_obstacles(self: @TContractState) -> u16;
+    // fn strength_bonus_damage(self: @TContractState) -> u8;
 
     // contract details
     fn owner_of(self: @TContractState, adventurer_id: felt252) -> ContractAddress;

--- a/contracts/game/src/tests/test_game.cairo
+++ b/contracts/game/src/tests/test_game.cairo
@@ -10,7 +10,6 @@ mod tests {
         ArcadeAccountABIDispatcher, ArcadeAccountABIDispatcherTrait,
         ArcadeAccountCamelABIDispatcher, ArcadeAccountCamelABIDispatcherTrait,
     };
-    use game_entropy::game_entropy::IGameEntropy;
     use array::ArrayTrait;
     use core::{result::ResultTrait, traits::Into, array::SpanTrait, serde::Serde, clone::Clone};
     use option::OptionTrait;

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -8,6 +8,7 @@ collectible_address=0x06a519DCcd7Ed4D1aACD3975691AEEae47bF7f9F5b62Ed7C2D929D2E27
 golden_token_address=0x06a519DCcd7Ed4D1aACD3975691AEEae47bF7f9F5b62Ed7C2D929D2E27A9CC5E
 terminal_timestamp=0
 randomness_contract=0x60c69136b39319547a4df303b6b3a26fab8b2d78de90b6bd215ce82e9cb515c
+randomness_rotation_interval=1
 client_reward_address=0x06a519DCcd7Ed4D1aACD3975691AEEae47bF7f9F5b62Ed7C2D929D2E27A9CC5E
 starting_weapon=12
 player_name=0x706c6179657231
@@ -35,7 +36,7 @@ sleep 10
 echo "lords contract: " $lords_contract
 
 # deploy game
-game_contract=$(starkli deploy --watch $game_class_hash $lords_contract $dao_address $collectible_address $golden_token_address $terminal_timestamp $randomness_contract --account $STARKNET_ACCOUNT --private-key $PRIVATE_KEY --max-fee-raw 12224764349828573 2>/dev/null)
+game_contract=$(starkli deploy --watch $game_class_hash $lords_contract $dao_address $collectible_address $golden_token_address $terminal_timestamp $randomness_contract $randomness_rotation_interval --account $STARKNET_ACCOUNT --private-key $PRIVATE_KEY --max-fee-raw 12224764349828573 2>/dev/null)
 echo "game contract: " $game_contract
 sleep 10
 


### PR DESCRIPTION
- add adventurer_entropy to AdventurerState which is used in most events. This allows clients to detect when contract is fetching new entropy as it'll zero out current entropy while it waits and prevent actions until new entropy arrives.
- removes lingering references to game entropy