### PR TITLE
use unique pragma seed on start game

### DIFF
--- a/contracts/beasts/src/beast.cairo
+++ b/contracts/beasts/src/beast.cairo
@@ -421,7 +421,7 @@ mod tests {
         let adventurer_level = 255; // max u8
         assert(
             ImplBeast::get_starting_health(
-                adventurer_level, 340282366920938463463374607431768211455
+                adventurer_level, 1022
             ) == MAXIMUM_HEALTH,
             'beast health should be max'
         );

--- a/contracts/game/src/lib.cairo
+++ b/contracts/game/src/lib.cairo
@@ -1354,7 +1354,7 @@ mod Game {
         if chain_id != KATANA_CHAIN_ID {
             let randomness_address = self._randomness_contract_address.read();
             request_randomness(
-                randomness_address, adventurer.xp.into(), adventurer_id, vrf_fee_limit
+                randomness_address, adventurer_id.try_into().unwrap(), adventurer_id, vrf_fee_limit
             );
         }
 


### PR DESCRIPTION
- previous implementation used adventurer xp which would always be 0
- new implementation uses adventurer id which will always be unique
- pragma is using additional sources of randomness which is why this was not resulting in same starting stats for all games