### PR TITLE
fixes beast attacking same armor location during equipment change

### DIFF
--- a/contracts/adventurer/src/adventurer.cairo
+++ b/contracts/adventurer/src/adventurer.cairo
@@ -48,6 +48,7 @@ struct Adventurer {
     stat_upgrades_available: u8, // 4 bits
     stats: Stats, // 30 bits
     equipment: Equipment, // 128 bits
+    // battle_action_count: u16 // 9 bits
     mutated: bool, // not packed
 }
 

--- a/contracts/adventurer/src/adventurer.cairo
+++ b/contracts/adventurer/src/adventurer.cairo
@@ -48,7 +48,6 @@ struct Adventurer {
     stat_upgrades_available: u8, // 4 bits
     stats: Stats, // 30 bits
     equipment: Equipment, // 128 bits
-    // battle_action_count: u16 // 9 bits
     mutated: bool, // not packed
 }
 

--- a/contracts/game/src/lib.cairo
+++ b/contracts/game/src/lib.cairo
@@ -445,9 +445,8 @@ mod Game {
                 // get beast and beast seed
                 let (beast, beast_seed) = adventurer.get_beast(adventurer_entropy);
 
-                // get two random numbers
-                let (rnd1, rnd2) = AdventurerUtils::get_randomness(
-                    adventurer.xp, adventurer_entropy
+                let (_, attack_location_rnd) = AdventurerUtils::get_randomness_with_health(
+                    adventurer.xp, adventurer.health, adventurer_entropy
                 );
 
                 // process beast attack
@@ -459,8 +458,8 @@ mod Game {
                     beast,
                     beast_seed,
                     start_entropy,
-                    rnd1,
-                    rnd2,
+                    attack_location_rnd,
+                    attack_location_rnd,
                     false
                 );
 


### PR DESCRIPTION
- This was throwing off prescience due to predict beast attack location differing from actual when player swapped items
- This also provides unwanted prescience steering by allowing player to change where the beast attacks and therefore change damage amount