### PR TITLE
improves starter beast experience

### DIFF
--- a/contracts/adventurer/src/adventurer.cairo
+++ b/contracts/adventurer/src/adventurer.cairo
@@ -281,12 +281,14 @@ impl ImplAdventurer of IAdventurer {
         ImplCombat::get_level_from_xp(self.xp)
     }
 
-    fn get_beast(self: Adventurer, adventurer_entropy: felt252) -> (Beast, u128) {
-        let beast_seed: u128 = self.get_beast_seed(adventurer_entropy);
+    fn get_beast(
+        self: Adventurer, adventurer_id: felt252, adventurer_entropy: felt252
+    ) -> (Beast, u128) {
         let adventurer_level = self.get_level();
 
         // @dev ideally this would be a setting but to minimize gas we're using hardcoded value so we can use cheaper equal operator
         if (adventurer_level == 1) {
+            let beast_seed: u128 = adventurer_id.try_into().unwrap();
             (
                 ImplBeast::get_starter_beast(
                     ImplLoot::get_type(self.equipment.weapon.id), beast_seed
@@ -294,6 +296,7 @@ impl ImplAdventurer of IAdventurer {
                 beast_seed
             )
         } else {
+            let beast_seed: u128 = self.get_beast_seed(adventurer_entropy);
             let beast_id = ImplBeast::get_beast_id(beast_seed);
             let starting_health = ImplBeast::get_starting_health(adventurer_level, beast_seed);
             let beast_tier = ImplBeast::get_tier(beast_id);
@@ -1420,7 +1423,7 @@ mod tests {
 
         let entropy = 1;
         // check new adventurer (level 1) gets a starter beast
-        let (beast, _) = adventurer.get_beast(entropy);
+        let (beast, _) = adventurer.get_beast(1, entropy);
         assert(beast.combat_spec.level == 1, 'beast should be lvl1');
         assert(beast.combat_spec.specials.special1 == 0, 'beast should have no special1');
         assert(beast.combat_spec.specials.special2 == 0, 'beast should have no special2');
@@ -1428,7 +1431,7 @@ mod tests {
 
         let entropy = 2;
         // check beast is still starter beast with different entropy source
-        let (beast, _) = adventurer.get_beast(entropy);
+        let (beast, _) = adventurer.get_beast(1, entropy);
         assert(beast.combat_spec.level == 1, 'beast should be lvl1');
         assert(beast.combat_spec.specials.special1 == 0, 'beast should have no special1');
         assert(beast.combat_spec.specials.special2 == 0, 'beast should have no special2');
@@ -1437,9 +1440,9 @@ mod tests {
         // advance adventurer to level 2
         adventurer.xp = 4;
         let entropy = 1;
-        let (beast1, _) = adventurer.get_beast(entropy);
+        let (beast1, _) = adventurer.get_beast(1, entropy);
         let entropy = 2;
-        let (beast2, _) = adventurer.get_beast(entropy);
+        let (beast2, _) = adventurer.get_beast(1, entropy);
 
         // verify beasts are the same since the seed did not change
         assert(beast1.id != beast2.id, 'beasts not unique');
@@ -1541,7 +1544,7 @@ mod tests {
             match AdventurerUtils::get_random_explore(r) {
                 ExploreResult::Beast(()) => {
                     total_beasts += 1;
-                    let (beast, _seed) = adventurer.get_beast(adventurer_entropy);
+                    let (beast, _seed) = adventurer.get_beast(1, adventurer_entropy);
                     if beast.id == BeastId::Warlock {
                         warlock_count += 1;
                     } else if beast.id == BeastId::Typhon {
@@ -1703,109 +1706,67 @@ mod tests {
 
         // assert beasts distributions are reasonably uniform
         let warlock_percentage = (warlock_count * 1000) / total_beasts;
-        assert(
-            warlock_percentage >= 7 && warlock_percentage <= 21, 'warlock distribution'
-        );
+        assert(warlock_percentage >= 7 && warlock_percentage <= 21, 'warlock distribution');
 
         let typhon_percentage = (typhon_count * 1000) / total_beasts;
-        assert(
-            typhon_percentage >= 7 && typhon_percentage <= 21, 'typhon distribution'
-        );
+        assert(typhon_percentage >= 7 && typhon_percentage <= 21, 'typhon distribution');
 
         let jiangshi_percentage = (jiangshi_count * 1000) / total_beasts;
-        assert(
-            jiangshi_percentage >= 7 && jiangshi_percentage <= 21, 'jiangshi distribution'
-        );
+        assert(jiangshi_percentage >= 7 && jiangshi_percentage <= 21, 'jiangshi distribution');
 
         let anansi_percentage = (anansi_count * 1000) / total_beasts;
-        assert(
-            anansi_percentage >= 7 && anansi_percentage <= 21, 'anansi distribution'
-        );
+        assert(anansi_percentage >= 7 && anansi_percentage <= 21, 'anansi distribution');
 
         let basilisk_percentage = (basilisk_count * 1000) / total_beasts;
-        assert(
-            basilisk_percentage >= 7 && basilisk_percentage <= 21, 'basilisk distribution'
-        );
+        assert(basilisk_percentage >= 7 && basilisk_percentage <= 21, 'basilisk distribution');
 
         let gorgon_percentage = (gorgon_count * 1000) / total_beasts;
-        assert(
-            gorgon_percentage >= 7 && gorgon_percentage <= 21, 'gorgon distribution'
-        );
+        assert(gorgon_percentage >= 7 && gorgon_percentage <= 21, 'gorgon distribution');
 
         let kitsune_percentage = (kitsune_count * 1000) / total_beasts;
-        assert(
-            kitsune_percentage >= 7 && kitsune_percentage <= 21, 'kitsune distribution'
-        );
+        assert(kitsune_percentage >= 7 && kitsune_percentage <= 21, 'kitsune distribution');
 
         let lich_percentage = (lich_count * 1000) / total_beasts;
-        assert(
-            lich_percentage >= 7 && lich_percentage <= 21, 'lich distribution'
-        );
+        assert(lich_percentage >= 7 && lich_percentage <= 21, 'lich distribution');
 
         let chimera_percentage = (chimera_count * 1000) / total_beasts;
-        assert(
-            chimera_percentage >= 7 && chimera_percentage <= 21, 'chimera distribution'
-        );
+        assert(chimera_percentage >= 7 && chimera_percentage <= 21, 'chimera distribution');
 
         let wendigo_percentage = (wendigo_count * 1000) / total_beasts;
-        assert(
-            wendigo_percentage >= 7 && wendigo_percentage <= 21, 'wendigo distribution'
-        );
+        assert(wendigo_percentage >= 7 && wendigo_percentage <= 21, 'wendigo distribution');
 
         let raksasa_percentage = (raksasa_count * 1000) / total_beasts;
-        assert(
-            raksasa_percentage >= 7 && raksasa_percentage <= 21, 'raksasa distribution'
-        );
+        assert(raksasa_percentage >= 7 && raksasa_percentage <= 21, 'raksasa distribution');
 
         let werewolf_percentage = (werewolf_count * 1000) / total_beasts;
-        assert(
-            werewolf_percentage >= 7 && werewolf_percentage <= 21, 'werewolf distribution'
-        );
+        assert(werewolf_percentage >= 7 && werewolf_percentage <= 21, 'werewolf distribution');
 
         let banshee_percentage = (banshee_count * 1000) / total_beasts;
-        assert(
-            banshee_percentage >= 7 && banshee_percentage <= 21, 'banshee distribution'
-        );
+        assert(banshee_percentage >= 7 && banshee_percentage <= 21, 'banshee distribution');
 
         let draugr_percentage = (draugr_count * 1000) / total_beasts;
-        assert(
-            draugr_percentage >= 7 && draugr_percentage <= 21, 'draugr distribution'
-        );
+        assert(draugr_percentage >= 7 && draugr_percentage <= 21, 'draugr distribution');
 
         let vampire_percentage = (vampire_count * 1000) / total_beasts;
-        assert(
-            vampire_percentage >= 7 && vampire_percentage <= 21, 'vampire distribution'
-        );
+        assert(vampire_percentage >= 7 && vampire_percentage <= 21, 'vampire distribution');
 
         let goblin_percentage = (goblin_count * 1000) / total_beasts;
-        assert(
-            goblin_percentage >= 7 && goblin_percentage <= 21, 'goblin distribution'
-        );
+        assert(goblin_percentage >= 7 && goblin_percentage <= 21, 'goblin distribution');
 
         let ghoul_percentage = (ghoul_count * 1000) / total_beasts;
-        assert(
-            ghoul_percentage >= 7 && ghoul_percentage <= 21, 'ghoul distribution'
-        );
+        assert(ghoul_percentage >= 7 && ghoul_percentage <= 21, 'ghoul distribution');
 
         let wraith_percentage = (wraith_count * 1000) / total_beasts;
-        assert(
-            wraith_percentage >= 7 && wraith_percentage <= 21, 'wraith distribution'
-        );
+        assert(wraith_percentage >= 7 && wraith_percentage <= 21, 'wraith distribution');
 
         let sprite_percentage = (sprite_count * 1000) / total_beasts;
-        assert(
-            sprite_percentage >= 7 && sprite_percentage <= 21, 'sprite distribution'
-        );
+        assert(sprite_percentage >= 7 && sprite_percentage <= 21, 'sprite distribution');
 
         let kappa_percentage = (kappa_count * 1000) / total_beasts;
-        assert(
-            kappa_percentage >= 7 && kappa_percentage <= 21, 'kappa distribution'
-        );
+        assert(kappa_percentage >= 7 && kappa_percentage <= 21, 'kappa distribution');
 
         let fairy_percentage = (fairy_count * 1000) / total_beasts;
-        assert(
-            fairy_percentage >= 7 && fairy_percentage <= 21, 'fairy distribution'
-        );
+        assert(fairy_percentage >= 7 && fairy_percentage <= 21, 'fairy distribution');
 
         let leprechaun_percentage = (leprechaun_count * 1000) / total_beasts;
         assert(
@@ -1813,59 +1774,37 @@ mod tests {
         );
 
         let kelpie_percentage = (kelpie_count * 1000) / total_beasts;
-        assert(
-            kelpie_percentage >= 7 && kelpie_percentage <= 21, 'kelpie distribution'
-        );
+        assert(kelpie_percentage >= 7 && kelpie_percentage <= 21, 'kelpie distribution');
 
         let pixie_percentage = (pixie_count * 1000) / total_beasts;
-        assert(
-            pixie_percentage >= 7 && pixie_percentage <= 21, 'pixie distribution'
-        );
+        assert(pixie_percentage >= 7 && pixie_percentage <= 21, 'pixie distribution');
 
         let gnome_percentage = (gnome_count * 1000) / total_beasts;
-        assert(
-            gnome_percentage >= 7 && gnome_percentage <= 21, 'gnome distribution'
-        );
+        assert(gnome_percentage >= 7 && gnome_percentage <= 21, 'gnome distribution');
 
         let griffin_percentage = (griffin_count * 1000) / total_beasts;
-        assert(
-            griffin_percentage >= 7 && griffin_percentage <= 21, 'griffin distribution'
-        );
+        assert(griffin_percentage >= 7 && griffin_percentage <= 21, 'griffin distribution');
 
         let manticore_percentage = (manticore_count * 1000) / total_beasts;
-        assert(
-            manticore_percentage >= 7 && manticore_percentage <= 21, 'manticore distribution'
-        );
+        assert(manticore_percentage >= 7 && manticore_percentage <= 21, 'manticore distribution');
 
         let phoenix_percentage = (phoenix_count * 1000) / total_beasts;
-        assert(
-            phoenix_percentage >= 7 && phoenix_percentage <= 21, 'phoenix distribution'
-        );
+        assert(phoenix_percentage >= 7 && phoenix_percentage <= 21, 'phoenix distribution');
 
         let dragon_percentage = (dragon_count * 1000) / total_beasts;
-        assert(
-            dragon_percentage >= 7 && dragon_percentage <= 21, 'dragon distribution'
-        );
+        assert(dragon_percentage >= 7 && dragon_percentage <= 21, 'dragon distribution');
 
         let minotaur_percentage = (minotaur_count * 1000) / total_beasts;
-        assert(
-            minotaur_percentage >= 7 && minotaur_percentage <= 21, 'minotaur distribution'
-        );
+        assert(minotaur_percentage >= 7 && minotaur_percentage <= 21, 'minotaur distribution');
 
         let qilin_percentage = (qilin_count * 1000) / total_beasts;
-        assert(
-            qilin_percentage >= 7 && qilin_percentage <= 21, 'qilin distribution'
-        );
+        assert(qilin_percentage >= 7 && qilin_percentage <= 21, 'qilin distribution');
 
         let ammit_percentage = (ammit_count * 1000) / total_beasts;
-        assert(
-            ammit_percentage >= 7 && ammit_percentage <= 21, 'ammit distribution'
-        );
+        assert(ammit_percentage >= 7 && ammit_percentage <= 21, 'ammit distribution');
 
         let nue_percentage = (nue_count * 1000) / total_beasts;
-        assert(
-            nue_percentage >= 7 && nue_percentage <= 21, 'nue distribution'
-        );
+        assert(nue_percentage >= 7 && nue_percentage <= 21, 'nue distribution');
 
         let skinwalker_percentage = (skinwalker_count * 1000) / total_beasts;
         assert(
@@ -1878,29 +1817,19 @@ mod tests {
         );
 
         let weretiger_percentage = (weretiger_count * 1000) / total_beasts;
-        assert(
-            weretiger_percentage >= 7 && weretiger_percentage <= 21, 'weretiger distribution'
-        );
+        assert(weretiger_percentage >= 7 && weretiger_percentage <= 21, 'weretiger distribution');
 
         let wyvern_percentage = (wyvern_count * 1000) / total_beasts;
-        assert(
-            wyvern_percentage >= 7 && wyvern_percentage <= 21, 'wyvern distribution'
-        );
+        assert(wyvern_percentage >= 7 && wyvern_percentage <= 21, 'wyvern distribution');
 
         let roc_percentage = (roc_count * 1000) / total_beasts;
-        assert(
-            roc_percentage >= 7 && roc_percentage <= 21, 'roc distribution'
-        );
+        assert(roc_percentage >= 7 && roc_percentage <= 21, 'roc distribution');
 
         let harpy_percentage = (harpy_count * 1000) / total_beasts;
-        assert(
-            harpy_percentage >= 7 && harpy_percentage <= 21, 'harpy distribution'
-        );
+        assert(harpy_percentage >= 7 && harpy_percentage <= 21, 'harpy distribution');
 
         let pegasus_percentage = (pegasus_count * 1000) / total_beasts;
-        assert(
-            pegasus_percentage >= 7 && pegasus_percentage <= 21, 'pegasus distribution'
-        );
+        assert(pegasus_percentage >= 7 && pegasus_percentage <= 21, 'pegasus distribution');
 
         let hippogriff_percentage = (hippogriff_count * 1000) / total_beasts;
         assert(
@@ -1908,94 +1837,58 @@ mod tests {
         );
 
         let fenrir_percentage = (fenrir_count * 1000) / total_beasts;
-        assert(
-            fenrir_percentage >= 7 && fenrir_percentage <= 21, 'fenrir distribution'
-        );
+        assert(fenrir_percentage >= 7 && fenrir_percentage <= 21, 'fenrir distribution');
 
         let jaguar_percentage = (jaguar_count * 1000) / total_beasts;
-        assert(
-            jaguar_percentage >= 7 && jaguar_percentage <= 21, 'jaguar distribution'
-        );
+        assert(jaguar_percentage >= 7 && jaguar_percentage <= 21, 'jaguar distribution');
 
         let satori_percentage = (satori_count * 1000) / total_beasts;
-        assert(
-            satori_percentage >= 7 && satori_percentage <= 21, 'satori distribution'
-        );
+        assert(satori_percentage >= 7 && satori_percentage <= 21, 'satori distribution');
 
         let direwolf_percentage = (direwolf_count * 1000) / total_beasts;
-        assert(
-            direwolf_percentage >= 7 && direwolf_percentage <= 21, 'direwolf distribution'
-        );
+        assert(direwolf_percentage >= 7 && direwolf_percentage <= 21, 'direwolf distribution');
 
         let bear_percentage = (bear_count * 1000) / total_beasts;
-        assert(
-            bear_percentage >= 7 && bear_percentage <= 21, 'bear distribution'
-        );
+        assert(bear_percentage >= 7 && bear_percentage <= 21, 'bear distribution');
 
         let wolf_percentage = (wolf_count * 1000) / total_beasts;
-        assert(
-            wolf_percentage >= 7 && wolf_percentage <= 21, 'wolf distribution'
-        );
+        assert(wolf_percentage >= 7 && wolf_percentage <= 21, 'wolf distribution');
 
         let mantis_percentage = (mantis_count * 1000) / total_beasts;
-        assert(
-            mantis_percentage >= 7 && mantis_percentage <= 21, 'mantis distribution'
-        );
+        assert(mantis_percentage >= 7 && mantis_percentage <= 21, 'mantis distribution');
 
         let spider_percentage = (spider_count * 1000) / total_beasts;
-        assert(
-            spider_percentage >= 7 && spider_percentage <= 21, 'spider distribution'
-        );
+        assert(spider_percentage >= 7 && spider_percentage <= 21, 'spider distribution');
 
         let rat_percentage = (rat_count * 1000) / total_beasts;
-        assert(
-            rat_percentage >= 7 && rat_percentage <= 21, 'rat distribution'
-        );
+        assert(rat_percentage >= 7 && rat_percentage <= 21, 'rat distribution');
 
         let kraken_percentage = (kraken_count * 1000) / total_beasts;
-        assert(
-            kraken_percentage >= 7 && kraken_percentage <= 21, 'kraken distribution'
-        );
+        assert(kraken_percentage >= 7 && kraken_percentage <= 21, 'kraken distribution');
 
         let colossus_percentage = (colossus_count * 1000) / total_beasts;
-        assert(
-            colossus_percentage >= 7 && colossus_percentage <= 21, 'colossus distribution'
-        );
+        assert(colossus_percentage >= 7 && colossus_percentage <= 21, 'colossus distribution');
 
         let balrog_percentage = (balrog_count * 1000) / total_beasts;
-        assert(
-            balrog_percentage >= 7 && balrog_percentage <= 21, 'balrog distribution'
-        );
+        assert(balrog_percentage >= 7 && balrog_percentage <= 21, 'balrog distribution');
 
         let leviathan_percentage = (leviathan_count * 1000) / total_beasts;
-        assert(
-            leviathan_percentage >= 7 && leviathan_percentage <= 21, 'leviathan distribution'
-        );
+        assert(leviathan_percentage >= 7 && leviathan_percentage <= 21, 'leviathan distribution');
 
         let tarrasque_percentage = (tarrasque_count * 1000) / total_beasts;
-        assert(
-            tarrasque_percentage >= 7 && tarrasque_percentage <= 21, 'tarrasque distribution'
-        );
+        assert(tarrasque_percentage >= 7 && tarrasque_percentage <= 21, 'tarrasque distribution');
 
         let titan_percentage = (titan_count * 1000) / total_beasts;
-        assert(
-            titan_percentage >= 7 && titan_percentage <= 21, 'titan distribution'
-        );
+        assert(titan_percentage >= 7 && titan_percentage <= 21, 'titan distribution');
 
         let nephilim_percentage = (nephilim_count * 1000) / total_beasts;
-        assert(
-            nephilim_percentage >= 7 && nephilim_percentage <= 21, 'nephilim distribution'
-        );
+        assert(nephilim_percentage >= 7 && nephilim_percentage <= 21, 'nephilim distribution');
 
         let behemoth_percentage = (behemoth_count * 1000) / total_beasts;
-        assert(
-            behemoth_percentage >= 7 && behemoth_percentage <= 21, 'behemoth distribution'
-        );
+        assert(behemoth_percentage >= 7 && behemoth_percentage <= 21, 'behemoth distribution');
 
         let hydra_percentage = (hydra_count * 1000) / total_beasts;
-        assert(
-            hydra_percentage >= 7 && hydra_percentage <= 21, 'hydra distribution'
-        );
+        assert(hydra_percentage >= 7 && hydra_percentage <= 21, 'hydra distribution');
 
         let juggernaut_percentage = (juggernaut_count * 1000) / total_beasts;
         assert(
@@ -2003,29 +1896,19 @@ mod tests {
         );
 
         let oni_percentage = (oni_count * 1000) / total_beasts;
-        assert(
-            oni_percentage >= 7 && oni_percentage <= 21, 'oni distribution'
-        );
+        assert(oni_percentage >= 7 && oni_percentage <= 21, 'oni distribution');
 
         let jotunn_percentage = (jotunn_count * 1000) / total_beasts;
-        assert(
-            jotunn_percentage >= 7 && jotunn_percentage <= 21, 'jotunn distribution'
-        );
+        assert(jotunn_percentage >= 7 && jotunn_percentage <= 21, 'jotunn distribution');
 
         let ettin_percentage = (ettin_count * 1000) / total_beasts;
-        assert(
-            ettin_percentage >= 7 && ettin_percentage <= 21, 'ettin distribution'
-        );
+        assert(ettin_percentage >= 7 && ettin_percentage <= 21, 'ettin distribution');
 
         let cyclops_percentage = (cyclops_count * 1000) / total_beasts;
-        assert(
-            cyclops_percentage >= 7 && cyclops_percentage <= 21, 'cyclops distribution'
-        );
+        assert(cyclops_percentage >= 7 && cyclops_percentage <= 21, 'cyclops distribution');
 
         let giant_percentage = (giant_count * 1000) / total_beasts;
-        assert(
-            giant_percentage >= 7 && giant_percentage <= 21, 'giant distribution'
-        );
+        assert(giant_percentage >= 7 && giant_percentage <= 21, 'giant distribution');
 
         let nemean_lion_percentage = (nemean_lion_count * 1000) / total_beasts;
         assert(
@@ -2033,49 +1916,31 @@ mod tests {
         );
 
         let berserker_percentage = (berserker_count * 1000) / total_beasts;
-        assert(
-            berserker_percentage >= 7 && berserker_percentage <= 21, 'berserker distribution'
-        );
+        assert(berserker_percentage >= 7 && berserker_percentage <= 21, 'berserker distribution');
 
         let yeti_percentage = (yeti_count * 1000) / total_beasts;
-        assert(
-            yeti_percentage >= 7 && yeti_percentage <= 21, 'yeti distribution'
-        );
+        assert(yeti_percentage >= 7 && yeti_percentage <= 21, 'yeti distribution');
 
         let golem_percentage = (golem_count * 1000) / total_beasts;
-        assert(
-            golem_percentage >= 7 && golem_percentage <= 21, 'golem distribution'
-        );
+        assert(golem_percentage >= 7 && golem_percentage <= 21, 'golem distribution');
 
         let ent_percentage = (ent_count * 1000) / total_beasts;
-        assert(
-            ent_percentage >= 7 && ent_percentage <= 21, 'ent distribution'
-        );
+        assert(ent_percentage >= 7 && ent_percentage <= 21, 'ent distribution');
 
         let troll_percentage = (troll_count * 1000) / total_beasts;
-        assert(
-            troll_percentage >= 7 && troll_percentage <= 21, 'troll distribution'
-        );
+        assert(troll_percentage >= 7 && troll_percentage <= 21, 'troll distribution');
 
         let bigfoot_percentage = (bigfoot_count * 1000) / total_beasts;
-        assert(
-            bigfoot_percentage >= 7 && bigfoot_percentage <= 21, 'bigfoot distribution'
-        );
+        assert(bigfoot_percentage >= 7 && bigfoot_percentage <= 21, 'bigfoot distribution');
 
         let ogre_percentage = (ogre_count * 1000) / total_beasts;
-        assert(
-            ogre_percentage >= 7 && ogre_percentage <= 21, 'ogre distribution'
-        );
+        assert(ogre_percentage >= 7 && ogre_percentage <= 21, 'ogre distribution');
 
         let orc_percentage = (orc_count * 1000) / total_beasts;
-        assert(
-            orc_percentage >= 7 && orc_percentage <= 21, 'orc distribution'
-        );
+        assert(orc_percentage >= 7 && orc_percentage <= 21, 'orc distribution');
 
         let skeleton_percentage = (skeleton_count * 1000) / total_beasts;
-        assert(
-            skeleton_percentage >= 7 && skeleton_percentage <= 21, 'skeleton distribution'
-        );
+        assert(skeleton_percentage >= 7 && skeleton_percentage <= 21, 'skeleton distribution');
     }
 
     #[test]
@@ -2170,7 +2035,7 @@ mod tests {
             match AdventurerUtils::get_random_explore(r) {
                 ExploreResult::Beast(()) => {
                     total_beasts += 1;
-                    let (beast, _seed) = adventurer.get_beast(adventurer_entropy);
+                    let (beast, _seed) = adventurer.get_beast(1, adventurer_entropy);
                     if beast.id == BeastId::Warlock {
                         warlock_count += 1;
                     } else if beast.id == BeastId::Typhon {
@@ -2332,109 +2197,67 @@ mod tests {
 
         // assert beasts distributions are reasonably uniform
         let warlock_percentage = (warlock_count * 1000) / total_beasts;
-        assert(
-            warlock_percentage >= 7 && warlock_percentage <= 21, 'warlock distribution'
-        );
+        assert(warlock_percentage >= 7 && warlock_percentage <= 21, 'warlock distribution');
 
         let typhon_percentage = (typhon_count * 1000) / total_beasts;
-        assert(
-            typhon_percentage >= 7 && typhon_percentage <= 21, 'typhon distribution'
-        );
+        assert(typhon_percentage >= 7 && typhon_percentage <= 21, 'typhon distribution');
 
         let jiangshi_percentage = (jiangshi_count * 1000) / total_beasts;
-        assert(
-            jiangshi_percentage >= 7 && jiangshi_percentage <= 21, 'jiangshi distribution'
-        );
+        assert(jiangshi_percentage >= 7 && jiangshi_percentage <= 21, 'jiangshi distribution');
 
         let anansi_percentage = (anansi_count * 1000) / total_beasts;
-        assert(
-            anansi_percentage >= 7 && anansi_percentage <= 21, 'anansi distribution'
-        );
+        assert(anansi_percentage >= 7 && anansi_percentage <= 21, 'anansi distribution');
 
         let basilisk_percentage = (basilisk_count * 1000) / total_beasts;
-        assert(
-            basilisk_percentage >= 7 && basilisk_percentage <= 21, 'basilisk distribution'
-        );
+        assert(basilisk_percentage >= 7 && basilisk_percentage <= 21, 'basilisk distribution');
 
         let gorgon_percentage = (gorgon_count * 1000) / total_beasts;
-        assert(
-            gorgon_percentage >= 7 && gorgon_percentage <= 21, 'gorgon distribution'
-        );
+        assert(gorgon_percentage >= 7 && gorgon_percentage <= 21, 'gorgon distribution');
 
         let kitsune_percentage = (kitsune_count * 1000) / total_beasts;
-        assert(
-            kitsune_percentage >= 7 && kitsune_percentage <= 21, 'kitsune distribution'
-        );
+        assert(kitsune_percentage >= 7 && kitsune_percentage <= 21, 'kitsune distribution');
 
         let lich_percentage = (lich_count * 1000) / total_beasts;
-        assert(
-            lich_percentage >= 7 && lich_percentage <= 21, 'lich distribution'
-        );
+        assert(lich_percentage >= 7 && lich_percentage <= 21, 'lich distribution');
 
         let chimera_percentage = (chimera_count * 1000) / total_beasts;
-        assert(
-            chimera_percentage >= 7 && chimera_percentage <= 21, 'chimera distribution'
-        );
+        assert(chimera_percentage >= 7 && chimera_percentage <= 21, 'chimera distribution');
 
         let wendigo_percentage = (wendigo_count * 1000) / total_beasts;
-        assert(
-            wendigo_percentage >= 7 && wendigo_percentage <= 21, 'wendigo distribution'
-        );
+        assert(wendigo_percentage >= 7 && wendigo_percentage <= 21, 'wendigo distribution');
 
         let raksasa_percentage = (raksasa_count * 1000) / total_beasts;
-        assert(
-            raksasa_percentage >= 7 && raksasa_percentage <= 21, 'raksasa distribution'
-        );
+        assert(raksasa_percentage >= 7 && raksasa_percentage <= 21, 'raksasa distribution');
 
         let werewolf_percentage = (werewolf_count * 1000) / total_beasts;
-        assert(
-            werewolf_percentage >= 7 && werewolf_percentage <= 21, 'werewolf distribution'
-        );
+        assert(werewolf_percentage >= 7 && werewolf_percentage <= 21, 'werewolf distribution');
 
         let banshee_percentage = (banshee_count * 1000) / total_beasts;
-        assert(
-            banshee_percentage >= 7 && banshee_percentage <= 21, 'banshee distribution'
-        );
+        assert(banshee_percentage >= 7 && banshee_percentage <= 21, 'banshee distribution');
 
         let draugr_percentage = (draugr_count * 1000) / total_beasts;
-        assert(
-            draugr_percentage >= 7 && draugr_percentage <= 21, 'draugr distribution'
-        );
+        assert(draugr_percentage >= 7 && draugr_percentage <= 21, 'draugr distribution');
 
         let vampire_percentage = (vampire_count * 1000) / total_beasts;
-        assert(
-            vampire_percentage >= 7 && vampire_percentage <= 21, 'vampire distribution'
-        );
+        assert(vampire_percentage >= 7 && vampire_percentage <= 21, 'vampire distribution');
 
         let goblin_percentage = (goblin_count * 1000) / total_beasts;
-        assert(
-            goblin_percentage >= 7 && goblin_percentage <= 21, 'goblin distribution'
-        );
+        assert(goblin_percentage >= 7 && goblin_percentage <= 21, 'goblin distribution');
 
         let ghoul_percentage = (ghoul_count * 1000) / total_beasts;
-        assert(
-            ghoul_percentage >= 7 && ghoul_percentage <= 21, 'ghoul distribution'
-        );
+        assert(ghoul_percentage >= 7 && ghoul_percentage <= 21, 'ghoul distribution');
 
         let wraith_percentage = (wraith_count * 1000) / total_beasts;
-        assert(
-            wraith_percentage >= 7 && wraith_percentage <= 21, 'wraith distribution'
-        );
+        assert(wraith_percentage >= 7 && wraith_percentage <= 21, 'wraith distribution');
 
         let sprite_percentage = (sprite_count * 1000) / total_beasts;
-        assert(
-            sprite_percentage >= 7 && sprite_percentage <= 21, 'sprite distribution'
-        );
+        assert(sprite_percentage >= 7 && sprite_percentage <= 21, 'sprite distribution');
 
         let kappa_percentage = (kappa_count * 1000) / total_beasts;
-        assert(
-            kappa_percentage >= 7 && kappa_percentage <= 21, 'kappa distribution'
-        );
+        assert(kappa_percentage >= 7 && kappa_percentage <= 21, 'kappa distribution');
 
         let fairy_percentage = (fairy_count * 1000) / total_beasts;
-        assert(
-            fairy_percentage >= 7 && fairy_percentage <= 21, 'fairy distribution'
-        );
+        assert(fairy_percentage >= 7 && fairy_percentage <= 21, 'fairy distribution');
 
         let leprechaun_percentage = (leprechaun_count * 1000) / total_beasts;
         assert(
@@ -2442,59 +2265,37 @@ mod tests {
         );
 
         let kelpie_percentage = (kelpie_count * 1000) / total_beasts;
-        assert(
-            kelpie_percentage >= 7 && kelpie_percentage <= 21, 'kelpie distribution'
-        );
+        assert(kelpie_percentage >= 7 && kelpie_percentage <= 21, 'kelpie distribution');
 
         let pixie_percentage = (pixie_count * 1000) / total_beasts;
-        assert(
-            pixie_percentage >= 7 && pixie_percentage <= 21, 'pixie distribution'
-        );
+        assert(pixie_percentage >= 7 && pixie_percentage <= 21, 'pixie distribution');
 
         let gnome_percentage = (gnome_count * 1000) / total_beasts;
-        assert(
-            gnome_percentage >= 7 && gnome_percentage <= 21, 'gnome distribution'
-        );
+        assert(gnome_percentage >= 7 && gnome_percentage <= 21, 'gnome distribution');
 
         let griffin_percentage = (griffin_count * 1000) / total_beasts;
-        assert(
-            griffin_percentage >= 7 && griffin_percentage <= 21, 'griffin distribution'
-        );
+        assert(griffin_percentage >= 7 && griffin_percentage <= 21, 'griffin distribution');
 
         let manticore_percentage = (manticore_count * 1000) / total_beasts;
-        assert(
-            manticore_percentage >= 7 && manticore_percentage <= 21, 'manticore distribution'
-        );
+        assert(manticore_percentage >= 7 && manticore_percentage <= 21, 'manticore distribution');
 
         let phoenix_percentage = (phoenix_count * 1000) / total_beasts;
-        assert(
-            phoenix_percentage >= 7 && phoenix_percentage <= 21, 'phoenix distribution'
-        );
+        assert(phoenix_percentage >= 7 && phoenix_percentage <= 21, 'phoenix distribution');
 
         let dragon_percentage = (dragon_count * 1000) / total_beasts;
-        assert(
-            dragon_percentage >= 7 && dragon_percentage <= 21, 'dragon distribution'
-        );
+        assert(dragon_percentage >= 7 && dragon_percentage <= 21, 'dragon distribution');
 
         let minotaur_percentage = (minotaur_count * 1000) / total_beasts;
-        assert(
-            minotaur_percentage >= 7 && minotaur_percentage <= 21, 'minotaur distribution'
-        );
+        assert(minotaur_percentage >= 7 && minotaur_percentage <= 21, 'minotaur distribution');
 
         let qilin_percentage = (qilin_count * 1000) / total_beasts;
-        assert(
-            qilin_percentage >= 7 && qilin_percentage <= 21, 'qilin distribution'
-        );
+        assert(qilin_percentage >= 7 && qilin_percentage <= 21, 'qilin distribution');
 
         let ammit_percentage = (ammit_count * 1000) / total_beasts;
-        assert(
-            ammit_percentage >= 7 && ammit_percentage <= 21, 'ammit distribution'
-        );
+        assert(ammit_percentage >= 7 && ammit_percentage <= 21, 'ammit distribution');
 
         let nue_percentage = (nue_count * 1000) / total_beasts;
-        assert(
-            nue_percentage >= 7 && nue_percentage <= 21, 'nue distribution'
-        );
+        assert(nue_percentage >= 7 && nue_percentage <= 21, 'nue distribution');
 
         let skinwalker_percentage = (skinwalker_count * 1000) / total_beasts;
         assert(
@@ -2507,29 +2308,19 @@ mod tests {
         );
 
         let weretiger_percentage = (weretiger_count * 1000) / total_beasts;
-        assert(
-            weretiger_percentage >= 7 && weretiger_percentage <= 21, 'weretiger distribution'
-        );
+        assert(weretiger_percentage >= 7 && weretiger_percentage <= 21, 'weretiger distribution');
 
         let wyvern_percentage = (wyvern_count * 1000) / total_beasts;
-        assert(
-            wyvern_percentage >= 7 && wyvern_percentage <= 21, 'wyvern distribution'
-        );
+        assert(wyvern_percentage >= 7 && wyvern_percentage <= 21, 'wyvern distribution');
 
         let roc_percentage = (roc_count * 1000) / total_beasts;
-        assert(
-            roc_percentage >= 7 && roc_percentage <= 21, 'roc distribution'
-        );
+        assert(roc_percentage >= 7 && roc_percentage <= 21, 'roc distribution');
 
         let harpy_percentage = (harpy_count * 1000) / total_beasts;
-        assert(
-            harpy_percentage >= 7 && harpy_percentage <= 21, 'harpy distribution'
-        );
+        assert(harpy_percentage >= 7 && harpy_percentage <= 21, 'harpy distribution');
 
         let pegasus_percentage = (pegasus_count * 1000) / total_beasts;
-        assert(
-            pegasus_percentage >= 7 && pegasus_percentage <= 21, 'pegasus distribution'
-        );
+        assert(pegasus_percentage >= 7 && pegasus_percentage <= 21, 'pegasus distribution');
 
         let hippogriff_percentage = (hippogriff_count * 1000) / total_beasts;
         assert(
@@ -2537,94 +2328,58 @@ mod tests {
         );
 
         let fenrir_percentage = (fenrir_count * 1000) / total_beasts;
-        assert(
-            fenrir_percentage >= 7 && fenrir_percentage <= 21, 'fenrir distribution'
-        );
+        assert(fenrir_percentage >= 7 && fenrir_percentage <= 21, 'fenrir distribution');
 
         let jaguar_percentage = (jaguar_count * 1000) / total_beasts;
-        assert(
-            jaguar_percentage >= 7 && jaguar_percentage <= 21, 'jaguar distribution'
-        );
+        assert(jaguar_percentage >= 7 && jaguar_percentage <= 21, 'jaguar distribution');
 
         let satori_percentage = (satori_count * 1000) / total_beasts;
-        assert(
-            satori_percentage >= 7 && satori_percentage <= 21, 'satori distribution'
-        );
+        assert(satori_percentage >= 7 && satori_percentage <= 21, 'satori distribution');
 
         let direwolf_percentage = (direwolf_count * 1000) / total_beasts;
-        assert(
-            direwolf_percentage >= 7 && direwolf_percentage <= 21, 'direwolf distribution'
-        );
+        assert(direwolf_percentage >= 7 && direwolf_percentage <= 21, 'direwolf distribution');
 
         let bear_percentage = (bear_count * 1000) / total_beasts;
-        assert(
-            bear_percentage >= 7 && bear_percentage <= 21, 'bear distribution'
-        );
+        assert(bear_percentage >= 7 && bear_percentage <= 21, 'bear distribution');
 
         let wolf_percentage = (wolf_count * 1000) / total_beasts;
-        assert(
-            wolf_percentage >= 7 && wolf_percentage <= 21, 'wolf distribution'
-        );
+        assert(wolf_percentage >= 7 && wolf_percentage <= 21, 'wolf distribution');
 
         let mantis_percentage = (mantis_count * 1000) / total_beasts;
-        assert(
-            mantis_percentage >= 7 && mantis_percentage <= 21, 'mantis distribution'
-        );
+        assert(mantis_percentage >= 7 && mantis_percentage <= 21, 'mantis distribution');
 
         let spider_percentage = (spider_count * 1000) / total_beasts;
-        assert(
-            spider_percentage >= 7 && spider_percentage <= 21, 'spider distribution'
-        );
+        assert(spider_percentage >= 7 && spider_percentage <= 21, 'spider distribution');
 
         let rat_percentage = (rat_count * 1000) / total_beasts;
-        assert(
-            rat_percentage >= 7 && rat_percentage <= 21, 'rat distribution'
-        );
+        assert(rat_percentage >= 7 && rat_percentage <= 21, 'rat distribution');
 
         let kraken_percentage = (kraken_count * 1000) / total_beasts;
-        assert(
-            kraken_percentage >= 7 && kraken_percentage <= 21, 'kraken distribution'
-        );
+        assert(kraken_percentage >= 7 && kraken_percentage <= 21, 'kraken distribution');
 
         let colossus_percentage = (colossus_count * 1000) / total_beasts;
-        assert(
-            colossus_percentage >= 7 && colossus_percentage <= 21, 'colossus distribution'
-        );
+        assert(colossus_percentage >= 7 && colossus_percentage <= 21, 'colossus distribution');
 
         let balrog_percentage = (balrog_count * 1000) / total_beasts;
-        assert(
-            balrog_percentage >= 7 && balrog_percentage <= 21, 'balrog distribution'
-        );
+        assert(balrog_percentage >= 7 && balrog_percentage <= 21, 'balrog distribution');
 
         let leviathan_percentage = (leviathan_count * 1000) / total_beasts;
-        assert(
-            leviathan_percentage >= 7 && leviathan_percentage <= 21, 'leviathan distribution'
-        );
+        assert(leviathan_percentage >= 7 && leviathan_percentage <= 21, 'leviathan distribution');
 
         let tarrasque_percentage = (tarrasque_count * 1000) / total_beasts;
-        assert(
-            tarrasque_percentage >= 7 && tarrasque_percentage <= 21, 'tarrasque distribution'
-        );
+        assert(tarrasque_percentage >= 7 && tarrasque_percentage <= 21, 'tarrasque distribution');
 
         let titan_percentage = (titan_count * 1000) / total_beasts;
-        assert(
-            titan_percentage >= 7 && titan_percentage <= 21, 'titan distribution'
-        );
+        assert(titan_percentage >= 7 && titan_percentage <= 21, 'titan distribution');
 
         let nephilim_percentage = (nephilim_count * 1000) / total_beasts;
-        assert(
-            nephilim_percentage >= 7 && nephilim_percentage <= 21, 'nephilim distribution'
-        );
+        assert(nephilim_percentage >= 7 && nephilim_percentage <= 21, 'nephilim distribution');
 
         let behemoth_percentage = (behemoth_count * 1000) / total_beasts;
-        assert(
-            behemoth_percentage >= 7 && behemoth_percentage <= 21, 'behemoth distribution'
-        );
+        assert(behemoth_percentage >= 7 && behemoth_percentage <= 21, 'behemoth distribution');
 
         let hydra_percentage = (hydra_count * 1000) / total_beasts;
-        assert(
-            hydra_percentage >= 7 && hydra_percentage <= 21, 'hydra distribution'
-        );
+        assert(hydra_percentage >= 7 && hydra_percentage <= 21, 'hydra distribution');
 
         let juggernaut_percentage = (juggernaut_count * 1000) / total_beasts;
         assert(
@@ -2632,29 +2387,19 @@ mod tests {
         );
 
         let oni_percentage = (oni_count * 1000) / total_beasts;
-        assert(
-            oni_percentage >= 7 && oni_percentage <= 21, 'oni distribution'
-        );
+        assert(oni_percentage >= 7 && oni_percentage <= 21, 'oni distribution');
 
         let jotunn_percentage = (jotunn_count * 1000) / total_beasts;
-        assert(
-            jotunn_percentage >= 7 && jotunn_percentage <= 21, 'jotunn distribution'
-        );
+        assert(jotunn_percentage >= 7 && jotunn_percentage <= 21, 'jotunn distribution');
 
         let ettin_percentage = (ettin_count * 1000) / total_beasts;
-        assert(
-            ettin_percentage >= 7 && ettin_percentage <= 21, 'ettin distribution'
-        );
+        assert(ettin_percentage >= 7 && ettin_percentage <= 21, 'ettin distribution');
 
         let cyclops_percentage = (cyclops_count * 1000) / total_beasts;
-        assert(
-            cyclops_percentage >= 7 && cyclops_percentage <= 21, 'cyclops distribution'
-        );
+        assert(cyclops_percentage >= 7 && cyclops_percentage <= 21, 'cyclops distribution');
 
         let giant_percentage = (giant_count * 1000) / total_beasts;
-        assert(
-            giant_percentage >= 7 && giant_percentage <= 21, 'giant distribution'
-        );
+        assert(giant_percentage >= 7 && giant_percentage <= 21, 'giant distribution');
 
         let nemean_lion_percentage = (nemean_lion_count * 1000) / total_beasts;
         assert(
@@ -2662,49 +2407,31 @@ mod tests {
         );
 
         let berserker_percentage = (berserker_count * 1000) / total_beasts;
-        assert(
-            berserker_percentage >= 7 && berserker_percentage <= 21, 'berserker distribution'
-        );
+        assert(berserker_percentage >= 7 && berserker_percentage <= 21, 'berserker distribution');
 
         let yeti_percentage = (yeti_count * 1000) / total_beasts;
-        assert(
-            yeti_percentage >= 7 && yeti_percentage <= 21, 'yeti distribution'
-        );
+        assert(yeti_percentage >= 7 && yeti_percentage <= 21, 'yeti distribution');
 
         let golem_percentage = (golem_count * 1000) / total_beasts;
-        assert(
-            golem_percentage >= 7 && golem_percentage <= 21, 'golem distribution'
-        );
+        assert(golem_percentage >= 7 && golem_percentage <= 21, 'golem distribution');
 
         let ent_percentage = (ent_count * 1000) / total_beasts;
-        assert(
-            ent_percentage >= 7 && ent_percentage <= 21, 'ent distribution'
-        );
+        assert(ent_percentage >= 7 && ent_percentage <= 21, 'ent distribution');
 
         let troll_percentage = (troll_count * 1000) / total_beasts;
-        assert(
-            troll_percentage >= 7 && troll_percentage <= 21, 'troll distribution'
-        );
+        assert(troll_percentage >= 7 && troll_percentage <= 21, 'troll distribution');
 
         let bigfoot_percentage = (bigfoot_count * 1000) / total_beasts;
-        assert(
-            bigfoot_percentage >= 7 && bigfoot_percentage <= 21, 'bigfoot distribution'
-        );
+        assert(bigfoot_percentage >= 7 && bigfoot_percentage <= 21, 'bigfoot distribution');
 
         let ogre_percentage = (ogre_count * 1000) / total_beasts;
-        assert(
-            ogre_percentage >= 7 && ogre_percentage <= 21, 'ogre distribution'
-        );
+        assert(ogre_percentage >= 7 && ogre_percentage <= 21, 'ogre distribution');
 
         let orc_percentage = (orc_count * 1000) / total_beasts;
-        assert(
-            orc_percentage >= 7 && orc_percentage <= 21, 'orc distribution'
-        );
+        assert(orc_percentage >= 7 && orc_percentage <= 21, 'orc distribution');
 
         let skeleton_percentage = (skeleton_count * 1000) / total_beasts;
-        assert(
-            skeleton_percentage >= 7 && skeleton_percentage <= 21, 'skeleton distribution'
-        );
+        assert(skeleton_percentage >= 7 && skeleton_percentage <= 21, 'skeleton distribution');
     }
 
     #[test]

--- a/contracts/beasts/src/beast.cairo
+++ b/contracts/beasts/src/beast.cairo
@@ -41,30 +41,22 @@ impl ImplBeast of IBeast {
     // the beast is chosen to be weak against the weapon type
     // @param starter_weapon_type: the type of weapon the adventurer starts with
     // @return: a beast that is weak against the weapon type
-    fn get_starter_beast(starter_weapon_type: Type, entropy: u128) -> Beast {
+    fn get_starter_beast(starter_weapon_type: Type, adventurer_id: u128) -> Beast {
         let mut beast_id: u8 = Gnome;
 
         match starter_weapon_type {
-            Type::None(()) => beast_id = Troll,
-            // if adventurer starts with a magical weapon, they start against T5 brute
+            Type::None(()) => { panic_with_felt252('weapon cannot be None'); },
             Type::Magic_or_Cloth(()) => {
-                let rnd_brute: u8 = (entropy % 5).try_into().unwrap() + Troll;
-                beast_id = rnd_brute
+                beast_id = (adventurer_id % 5).try_into().unwrap() + Troll;
             },
-            // if the adventurer starts with a bladed weapon, they start against T5 magical
             Type::Blade_or_Hide(()) => {
-                let rnd_magical: u8 = (entropy % 5).try_into().unwrap() + Fairy;
-                beast_id = rnd_magical
+                beast_id = (adventurer_id % 5).try_into().unwrap() + Fairy;
             },
-            // if the adventurer starts with a bludgeon weapon, they start against T5 hunter
             Type::Bludgeon_or_Metal(()) => {
-                let rnd_hunter: u8 = (entropy % 5).try_into().unwrap() + Bear;
-                beast_id = rnd_hunter
+                beast_id = (adventurer_id % 5).try_into().unwrap() + Bear;
             },
-            // starter weapon should never be a necklace or ring
-            // but cairo needs us to define all cases so just default to troll
-            Type::Necklace(()) => beast_id = Troll,
-            Type::Ring(()) => beast_id = Troll,
+            Type::Necklace(()) => { panic_with_felt252('weapon cannot be necklace'); },
+            Type::Ring(()) => { panic_with_felt252('weapon cannot be ring'); },
         }
 
         Beast {
@@ -420,9 +412,7 @@ mod tests {
         // test extremes
         let adventurer_level = 255; // max u8
         assert(
-            ImplBeast::get_starting_health(
-                adventurer_level, 1022
-            ) == MAXIMUM_HEALTH,
+            ImplBeast::get_starting_health(adventurer_level, 1022) == MAXIMUM_HEALTH,
             'beast health should be max'
         );
     }

--- a/contracts/game/src/game/constants.cairo
+++ b/contracts/game/src/game/constants.cairo
@@ -9,7 +9,7 @@ mod messages {
     const NOT_IN_BATTLE: felt252 = 'Not in battle';
     const ACTION_NOT_ALLOWED_DURING_BATTLE: felt252 = 'Action not allowed in battle';
     const CANT_FLEE_STARTER_BEAST: felt252 = 'Cant flee starter beast';
-    const CANT_DROP_STARTER_BEAST: felt252 = 'Cant drop starter beast';
+    const CANT_DROP_DURING_STARTER_BEAST: felt252 = 'Cant drop during starter beast';
     const STAT_UPGRADES_AVAILABLE: felt252 = 'Stat upgrade available';
     const BLOCK_NUMBER_ERROR: felt252 = 'Too soon update';
     const DEAD_ADVENTURER: felt252 = 'Adventurer is dead';

--- a/contracts/game/src/game/constants.cairo
+++ b/contracts/game/src/game/constants.cairo
@@ -9,6 +9,7 @@ mod messages {
     const NOT_IN_BATTLE: felt252 = 'Not in battle';
     const ACTION_NOT_ALLOWED_DURING_BATTLE: felt252 = 'Action not allowed in battle';
     const CANT_FLEE_STARTER_BEAST: felt252 = 'Cant flee starter beast';
+    const CANT_DROP_STARTER_BEAST: felt252 = 'Cant drop starter beast';
     const STAT_UPGRADES_AVAILABLE: felt252 = 'Stat upgrade available';
     const BLOCK_NUMBER_ERROR: felt252 = 'Too soon update';
     const DEAD_ADVENTURER: felt252 = 'Adventurer is dead';

--- a/contracts/game/src/lib.cairo
+++ b/contracts/game/src/lib.cairo
@@ -505,7 +505,7 @@ mod Game {
             _assert_ownership(@self, adventurer_id);
             _assert_not_dead(adventurer);
             assert(items.len() != 0, messages::NO_ITEMS);
-            _assert_not_starter_beast(adventurer, messages::CANT_DROP_STARTER_BEAST);
+            _assert_not_starter_beast(adventurer, messages::CANT_DROP_DURING_STARTER_BEAST);
 
             // drop items
             _drop(@self, ref adventurer, ref bag, adventurer_id, items.clone());

--- a/contracts/game/src/lib.cairo
+++ b/contracts/game/src/lib.cairo
@@ -505,6 +505,7 @@ mod Game {
             _assert_ownership(@self, adventurer_id);
             _assert_not_dead(adventurer);
             assert(items.len() != 0, messages::NO_ITEMS);
+            _assert_not_starter_beast(adventurer);
 
             // drop items
             _drop(@self, ref adventurer, ref bag, adventurer_id, items.clone());
@@ -1365,7 +1366,7 @@ mod Game {
         starting_weapon: u8,
         adventurer_entropy: felt252
     ) -> BattleDetails {
-        let beast_seed = adventurer.get_beast_seed(adventurer_entropy);
+        let beast_seed = adventurer_id.try_into().unwrap();
 
         // generate starter beast which will have weak armor against the adventurers starter weapon
         let starter_beast = ImplBeast::get_starter_beast(

--- a/contracts/game/src/lib.cairo
+++ b/contracts/game/src/lib.cairo
@@ -353,7 +353,7 @@ mod Game {
             );
 
             // get beast and beast seed
-            let (beast, beast_seed) = adventurer.get_beast(adventurer_entropy);
+            let (beast, beast_seed) = adventurer.get_beast(adventurer_id, adventurer_entropy);
 
             // get weapon details
             let weapon = ImplLoot::get_item(adventurer.equipment.weapon.id);
@@ -401,7 +401,7 @@ mod Game {
             _assert_entropy_set(@self, adventurer_id);
 
             // get beast and beast seed
-            let (beast, beast_seed) = adventurer.get_beast(adventurer_entropy);
+            let (beast, beast_seed) = adventurer.get_beast(adventurer_id, adventurer_entropy);
 
             // attempt to flee
             _flee(
@@ -453,7 +453,7 @@ mod Game {
             // if the adventurer is equipping an item during battle, the beast will counter attack
             if (adventurer.in_battle()) {
                 // get beast and beast seed
-                let (beast, beast_seed) = adventurer.get_beast(adventurer_entropy);
+                let (beast, beast_seed) = adventurer.get_beast(adventurer_id, adventurer_entropy);
 
                 let (_, attack_location_rnd) = AdventurerUtils::get_randomness_with_health(
                     adventurer.xp, adventurer.health, adventurer_entropy
@@ -1526,7 +1526,7 @@ mod Game {
         entropy: u128
     ) {
         // get beast and beast seed
-        let (beast, beast_seed) = adventurer.get_beast(adventurer_entropy);
+        let (beast, beast_seed) = adventurer.get_beast(adventurer_id, adventurer_entropy);
 
         // init beast health (this is only info about beast that we store)
         adventurer.beast_health = beast.starting_health;
@@ -2659,7 +2659,7 @@ mod Game {
         let adventurer_entropy = _get_adventurer_entropy(self, adventurer_id);
 
         // get beast and beast seed
-        let (beast, _) = adventurer.get_beast(adventurer_entropy);
+        let (beast, _) = adventurer.get_beast(adventurer_id, adventurer_entropy);
 
         // return beast
         beast

--- a/contracts/game/src/lib.cairo
+++ b/contracts/game/src/lib.cairo
@@ -396,7 +396,7 @@ mod Game {
             _assert_ownership(@self, adventurer_id);
             _assert_not_dead(immutable_adventurer);
             _assert_in_battle(immutable_adventurer);
-            _assert_not_starter_beast(immutable_adventurer);
+            _assert_not_starter_beast(immutable_adventurer, messages::CANT_FLEE_STARTER_BEAST);
             _assert_dexterity_not_zero(immutable_adventurer);
             _assert_entropy_set(@self, adventurer_id);
 
@@ -505,7 +505,7 @@ mod Game {
             _assert_ownership(@self, adventurer_id);
             _assert_not_dead(adventurer);
             assert(items.len() != 0, messages::NO_ITEMS);
-            _assert_not_starter_beast(adventurer);
+            _assert_not_starter_beast(adventurer, messages::CANT_DROP_STARTER_BEAST);
 
             // drop items
             _drop(@self, ref adventurer, ref bag, adventurer_id, items.clone());
@@ -2545,9 +2545,10 @@ mod Game {
             messages::ITEM_DOES_NOT_EXIST
         );
     }
-    fn _assert_not_starter_beast(adventurer: Adventurer) {
-        assert(adventurer.get_level() > 1, messages::CANT_FLEE_STARTER_BEAST);
+    fn _assert_not_starter_beast(adventurer: Adventurer, message: felt252) {
+        assert(adventurer.get_level() > 1, message);
     }
+
     fn _assert_no_stat_upgrades_available(adventurer: Adventurer) {
         assert(adventurer.stat_upgrades_available == 0, messages::STAT_UPGRADES_AVAILABLE);
     }

--- a/contracts/game/src/tests/test_game.cairo
+++ b/contracts/game/src/tests/test_game.cairo
@@ -238,8 +238,13 @@ mod tests {
         (game, lords, eth, golden_token, OWNER())
     }
 
-    fn add_adventurer_to_game(ref game: IGameDispatcher, golden_token_id: u256) {
-        game.new_game(INTERFACE_ID(), ItemId::Wand, 'loothero', golden_token_id, 4000000000000000);
+    fn add_adventurer_to_game(
+        ref game: IGameDispatcher, golden_token_id: u256, starting_weapon: u8
+    ) {
+        game
+            .new_game(
+                INTERFACE_ID(), starting_weapon, 'loothero', golden_token_id, 4000000000000000
+            );
 
         let original_adventurer = game.get_adventurer(ADVENTURER_ID);
         assert(original_adventurer.xp == 0, 'wrong starting xp');
@@ -1667,14 +1672,14 @@ mod tests {
         let (mut game, _, _, _, _) = setup(starting_block, starting_timestamp, terminal_timestamp);
 
         // add a player to the game
-        add_adventurer_to_game(ref game, 0);
+        add_adventurer_to_game(ref game, 0, ItemId::Wand);
         // advance blockchain timestamp beyond terminal timestamp
         starknet::testing::set_block_timestamp(terminal_timestamp + 1);
 
         // try to start a new game
         // should panic with 'terminal time reached'
         // which test is annotated to expect
-        add_adventurer_to_game(ref game, 0);
+        add_adventurer_to_game(ref game, 0, ItemId::Wand);
     }
 
     #[test]
@@ -1686,14 +1691,14 @@ mod tests {
         let (mut game, _, _, _, _) = setup(starting_block, starting_timestamp, terminal_timestamp);
 
         // add a player to the game
-        add_adventurer_to_game(ref game, 0);
+        add_adventurer_to_game(ref game, 0, ItemId::Wand);
 
         // advance blockchain timestamp to max u64
         let max_u64_timestamp = 18446744073709551615;
         starknet::testing::set_block_timestamp(max_u64_timestamp);
 
         // verify we can still start a new game
-        add_adventurer_to_game(ref game, 0);
+        add_adventurer_to_game(ref game, 0, ItemId::Wand);
     }
 
     #[test]
@@ -1703,9 +1708,9 @@ mod tests {
         let starting_timestamp = 1698678554;
         let terminal_timestamp = 0;
         let (mut game, _, _, _, _) = setup(starting_block, starting_timestamp, terminal_timestamp);
-        add_adventurer_to_game(ref game, 1);
+        add_adventurer_to_game(ref game, 1, ItemId::Wand);
         testing::set_block_timestamp(starting_timestamp + DAY);
-        add_adventurer_to_game(ref game, 1);
+        add_adventurer_to_game(ref game, 1, ItemId::Wand);
     }
 
     #[test]
@@ -1717,7 +1722,7 @@ mod tests {
         let terminal_timestamp = 0;
         let (mut game, _, _, _, _) = setup(starting_block, starting_timestamp, terminal_timestamp);
         assert(game.can_play(1), 'should be able to play');
-        add_adventurer_to_game(ref game, golden_token_id);
+        add_adventurer_to_game(ref game, golden_token_id, ItemId::Wand);
         assert(!game.can_play(1), 'should not be able to play');
         testing::set_block_timestamp(starting_timestamp + DAY);
         assert(game.can_play(1), 'should be able to play again');
@@ -1734,7 +1739,7 @@ mod tests {
         let starting_timestamp = 1698678554;
         let terminal_timestamp = 0;
         let (mut game, _, _, _, _) = setup(starting_block, starting_timestamp, terminal_timestamp);
-        add_adventurer_to_game(ref game, golden_token_id);
+        add_adventurer_to_game(ref game, golden_token_id, ItemId::Wand);
     }
 
     #[test]
@@ -1746,13 +1751,13 @@ mod tests {
         let starting_timestamp = 1698678554;
         let terminal_timestamp = 0;
         let (mut game, _, _, _, _) = setup(starting_block, starting_timestamp, terminal_timestamp);
-        add_adventurer_to_game(ref game, golden_token_id);
+        add_adventurer_to_game(ref game, golden_token_id, ItemId::Wand);
 
         // roll blockchain forward 1 second less than a day
         testing::set_block_timestamp(starting_timestamp + (DAY - 1));
 
         // try to play again with golden token which should cause panic
-        add_adventurer_to_game(ref game, golden_token_id);
+        add_adventurer_to_game(ref game, golden_token_id, ItemId::Wand);
     }
 
     #[test]
@@ -1773,6 +1778,121 @@ mod tests {
         // try to drop starter weapon during starter beast battle
         let mut drop_items = array![ItemId::Wand];
         game.drop(ADVENTURER_ID, drop_items);
+    }
+
+    #[test]
+    fn test_different_starter_beasts() {
+        let starting_block = 364063;
+        let starting_timestamp = 1698678554;
+        let (mut game, _, _, _, _) = setup(starting_block, starting_timestamp, 0);
+        let mut game_count = game.get_game_count();
+        assert(game_count == 0, 'game count should be 0');
+
+        add_adventurer_to_game(ref game, 0, ItemId::Wand);
+        game_count = game.get_game_count();
+        let starter_beast_game_one = game.get_attacking_beast(game_count).id;
+        assert(game_count == 1, 'game count should be 1');
+
+        add_adventurer_to_game(ref game, 0, ItemId::Wand);
+        game_count = game.get_game_count();
+        let starter_beast_game_two = game.get_attacking_beast(game_count).id;
+        assert(game_count == 2, 'game count should be 2');
+
+        add_adventurer_to_game(ref game, 0, ItemId::Wand);
+        game_count = game.get_game_count();
+        let starter_beast_game_three = game.get_attacking_beast(game_count).id;
+        assert(game_count == 3, 'game count should be 3');
+
+        add_adventurer_to_game(ref game, 0, ItemId::Wand);
+        game_count = game.get_game_count();
+        let starter_beast_game_four = game.get_attacking_beast(game_count).id;
+        assert(game_count == 4, 'game count should be 4');
+
+        add_adventurer_to_game(ref game, 0, ItemId::Wand);
+        game_count = game.get_game_count();
+        let starter_beast_game_five = game.get_attacking_beast(game_count).id;
+        assert(game_count == 5, 'game count should be 5');
+
+        add_adventurer_to_game(ref game, 0, ItemId::Wand);
+        game_count = game.get_game_count();
+        let starter_beast_game_six = game.get_attacking_beast(game_count).id;
+        assert(game_count == 6, 'game count should be 6');
+
+        // assert all games starting with a Wand get a T5 Brute for starter beast
+        assert(
+            starter_beast_game_one >= BeastId::Troll && starter_beast_game_one <= BeastId::Skeleton,
+            'wrong starter beast game 1'
+        );
+        assert(
+            starter_beast_game_two >= BeastId::Troll && starter_beast_game_one <= BeastId::Skeleton,
+            'wrong starter beast game 2'
+        );
+        assert(
+            starter_beast_game_three >= BeastId::Troll
+                && starter_beast_game_one <= BeastId::Skeleton,
+            'wrong starter beast game 3'
+        );
+        assert(
+            starter_beast_game_four >= BeastId::Troll
+                && starter_beast_game_one <= BeastId::Skeleton,
+            'wrong starter beast game 4'
+        );
+        assert(
+            starter_beast_game_five >= BeastId::Troll
+                && starter_beast_game_one <= BeastId::Skeleton,
+            'wrong starter beast game 5'
+        );
+
+        // assert first five games are all unique
+        assert(starter_beast_game_one != starter_beast_game_two, 'same starter beast game 1 & 2');
+        assert(starter_beast_game_one != starter_beast_game_three, 'same starter beast game 1 & 3');
+        assert(starter_beast_game_one != starter_beast_game_four, 'same starter beast game 1 & 4');
+        assert(starter_beast_game_one != starter_beast_game_five, 'same starter beast game 1 & 5');
+        assert(starter_beast_game_two != starter_beast_game_three, 'same starter beast game 2 & 3');
+        assert(starter_beast_game_two != starter_beast_game_four, 'same starter beast game 2 & 4');
+        assert(starter_beast_game_two != starter_beast_game_five, 'same starter beast game 2 & 5');
+        assert(
+            starter_beast_game_three != starter_beast_game_four, 'same starter beast game 3 & 4'
+        );
+        assert(
+            starter_beast_game_three != starter_beast_game_five, 'same starter beast game 3 & 5'
+        );
+        assert(starter_beast_game_four != starter_beast_game_five, 'same starter beast game 4 & 5');
+
+        // sixth game wraps around and gets same beast as the first game
+        assert(starter_beast_game_one == starter_beast_game_six, 'game 1 and 6 should be same');
+
+        // Assert Book start gets T5 Brutes
+        add_adventurer_to_game(ref game, 0, ItemId::Book);
+        game_count = game.get_game_count();
+        let starter_beast_book_start = game.get_attacking_beast(game_count).id;
+        assert(game_count == 7, 'game count should be 7');
+        assert(
+            starter_beast_book_start >= BeastId::Troll
+                && starter_beast_book_start <= BeastId::Skeleton,
+            'wrong starter beast for book'
+        );
+
+        // Assert Club start gets T5 Hunter
+        add_adventurer_to_game(ref game, 0, ItemId::Club);
+        game_count = game.get_game_count();
+        let starter_beast_club_start = game.get_attacking_beast(game_count).id;
+        assert(game_count == 8, 'game count should be 8');
+        assert(
+            starter_beast_club_start >= BeastId::Bear && starter_beast_club_start <= BeastId::Rat,
+            'wrong starter beast for club'
+        );
+
+        // Assert Club start gets T5 Hunter
+        add_adventurer_to_game(ref game, 0, ItemId::ShortSword);
+        game_count = game.get_game_count();
+        let starter_beast_sword_start = game.get_attacking_beast(game_count).id;
+        assert(game_count == 9, 'game count should be 9');
+        assert(
+            starter_beast_sword_start >= BeastId::Fairy
+                && starter_beast_sword_start <= BeastId::Gnome,
+            'wrong starter beast for sword'
+        );
     }
 
     #[starknet::contract]

--- a/contracts/game/src/tests/test_game.cairo
+++ b/contracts/game/src/tests/test_game.cairo
@@ -1755,6 +1755,26 @@ mod tests {
         add_adventurer_to_game(ref game, golden_token_id);
     }
 
+    #[test]
+    #[should_panic(expected: ('Cant drop starter beast', 'ENTRYPOINT_FAILED'))]
+    fn test_no_dropping_starter_weapon_during_starter_beast() {
+        let mut game = new_adventurer(1000, 1696201757);
+
+        // try to drop starter weapon during starter beast battle
+        let mut drop_items = array![ItemId::Wand];
+        game.drop(ADVENTURER_ID, drop_items);
+    }
+
+    #[test]
+    fn test_drop_starter_item_after_starter_beast() {
+        let mut game = new_adventurer(1000, 1696201757);
+        game.attack(ADVENTURER_ID, true);
+
+        // try to drop starter weapon during starter beast battle
+        let mut drop_items = array![ItemId::Wand];
+        game.drop(ADVENTURER_ID, drop_items);
+    }
+
     #[starknet::contract]
     mod SnakeERC20Mock {
         use openzeppelin::token::erc20::{ERC20Component, ERC20HooksEmptyImpl};

--- a/contracts/game/src/tests/test_game.cairo
+++ b/contracts/game/src/tests/test_game.cairo
@@ -1752,7 +1752,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected: ('Cant drop starter beast', 'ENTRYPOINT_FAILED'))]
+    #[should_panic(expected: ('Cant drop during starter beast', 'ENTRYPOINT_FAILED'))]
     fn test_no_dropping_starter_weapon_during_starter_beast() {
         let mut game = new_adventurer(1000, 1696201757);
 

--- a/contracts/game/src/tests/test_game.cairo
+++ b/contracts/game/src/tests/test_game.cairo
@@ -1283,15 +1283,6 @@ mod tests {
 
     #[test]
     #[available_gas(20000000)]
-    fn test_get_attacking_beast() {
-        let mut game = new_adventurer(1000, 1696201757);
-        let beast = game.get_attacking_beast(ADVENTURER_ID);
-        // our adventurer starts with a wand so the starter beast should be a troll
-        assert(beast.id == BeastId::Troll, 'starter beast should be troll');
-    }
-
-    #[test]
-    #[available_gas(20000000)]
     fn test_get_health() {
         let mut game = new_adventurer(1000, 1696201757);
         let adventurer = game.get_adventurer(ADVENTURER_ID);


### PR DESCRIPTION
- players will now see all five starter beasts for a type instead of just one
- fixes bug in which dropping starter weapon caused conflicting information in event
- dropping starter weapon during starter beast battle is no longer allowed