### PR TITLE
add testing for erc721

### DIFF
--- a/contracts/game/src/tests/test_game.cairo
+++ b/contracts/game/src/tests/test_game.cairo
@@ -1909,7 +1909,7 @@ mod tests {
         );
     }
 
-    fn tranfer_ownership(mut game: IGameDispatcher, from: ContractAddress, to: ContractAddress) {
+    fn transfer_ownership(mut game: IGameDispatcher, from: ContractAddress, to: ContractAddress) {
         // Some weird conflict when using the game interface ?? using direct ERC721Dispatcher for now. This is not a problem in blockexplorers, I suspect issue in Scarb compiler.
         IERC721Dispatcher { contract_address: game.contract_address }
             .transfer_from(from, to, ADVENTURER_ID.into());
@@ -1920,7 +1920,7 @@ mod tests {
     #[test]
     fn test_transfered_attack() {
         let mut game = new_adventurer(364063, 1698678554);
-        tranfer_ownership(game, OWNER(), OWNER_TWO());
+        transfer_ownership(game, OWNER(), OWNER_TWO());
 
         game.attack(ADVENTURER_ID, false);
     }
@@ -1930,7 +1930,7 @@ mod tests {
     #[should_panic(expected: ('Not authorized to act', 'ENTRYPOINT_FAILED'))]
     fn test_original_owner_attack() {
         let mut game = new_adventurer(364063, 1698678554);
-        tranfer_ownership(game, OWNER(), OWNER_TWO());
+        transfer_ownership(game, OWNER(), OWNER_TWO());
 
         testing::set_contract_address(OWNER());
 
@@ -1942,7 +1942,7 @@ mod tests {
     #[should_panic(expected: ('Not authorized to act', 'ENTRYPOINT_FAILED'))]
     fn test_original_owner_upgrade() {
         let mut game = new_adventurer_lvl2(364063, 1698678554, 0);
-        tranfer_ownership(game, OWNER(), OWNER_TWO());
+        transfer_ownership(game, OWNER(), OWNER_TWO());
 
         testing::set_contract_address(OWNER());
 
@@ -1957,7 +1957,7 @@ mod tests {
     #[should_panic(expected: ('Not authorized to act', 'ENTRYPOINT_FAILED'))]
     fn test_original_owner_explore() {
         let mut game = new_adventurer_lvl2(364063, 1698678554, 0);
-        tranfer_ownership(game, OWNER(), OWNER_TWO());
+        transfer_ownership(game, OWNER(), OWNER_TWO());
 
         let shopping_cart = ArrayTrait::<ItemPurchase>::new();
         let stat_upgrades = Stats {
@@ -1974,7 +1974,7 @@ mod tests {
     #[should_panic(expected: ('Not authorized to act', 'ENTRYPOINT_FAILED'))]
     fn test_original_owner_flee() {
         let mut game = new_adventurer_lvl2(364063, 1698678554, 0);
-        tranfer_ownership(game, OWNER(), OWNER_TWO());
+        transfer_ownership(game, OWNER(), OWNER_TWO());
 
         let shopping_cart = ArrayTrait::<ItemPurchase>::new();
         let stat_upgrades = Stats {
@@ -1993,18 +1993,25 @@ mod tests {
 
     #[test]
     fn test_transfered_upgrade_explore_flee() {
-        let mut game = new_adventurer_lvl2(364063, 1698678554, 0);
-        tranfer_ownership(game, OWNER(), OWNER_TWO());
+        let mut game = new_adventurer_lvl2(123, 1696201757, 0);
+        transfer_ownership(game, OWNER(), OWNER_TWO());
 
         let shopping_cart = ArrayTrait::<ItemPurchase>::new();
         let stat_upgrades = Stats {
-            strength: 0, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 1, luck: 0
+            strength: 0, dexterity: 1, vitality: 0, intelligence: 0, wisdom: 0, charisma: 0, luck: 0
         };
         game.upgrade(ADVENTURER_ID, 0, stat_upgrades, shopping_cart.clone());
 
         // go explore
         game.explore(ADVENTURER_ID, true);
         game.flee(ADVENTURER_ID, true);
+    }
+
+    // verify tokens transferred to transfered owner not original owner
+    #[test]
+    fn test_transfered_transfer() {
+        let mut game = new_adventurer(364063, 1698678554);
+        transfer_ownership(game, OWNER(), OWNER_TWO());
     }
 
 

--- a/contracts/game/src/tests/test_game.cairo
+++ b/contracts/game/src/tests/test_game.cairo
@@ -49,10 +49,11 @@ mod tests {
     use openzeppelin::utils::serde::SerializedAppend;
     use openzeppelin::token::erc721::dual721::{DualCaseERC721, DualCaseERC721Trait};
     use openzeppelin::token::erc721::interface::IERC721_ID;
+
     use openzeppelin::token::erc721::interface::{
+        IERC721, IERC721Dispatcher, IERC721DispatcherTrait, IERC721LibraryDispatcher,
         IERC721CamelOnlyDispatcher, IERC721CamelOnlyDispatcherTrait
     };
-    use openzeppelin::token::erc721::interface::{IERC721Dispatcher, IERC721DispatcherTrait};
 
     use starknet::testing::set_caller_address;
     use starknet::testing::set_contract_address;
@@ -101,6 +102,10 @@ mod tests {
 
     fn ZERO_ADDRESS() -> ContractAddress {
         contract_address_const::<0>()
+    }
+
+    fn OWNER_TWO() -> ContractAddress {
+        contract_address_const::<2>()
     }
 
     const PUBLIC_KEY: felt252 = 0x333333;
@@ -1903,6 +1908,105 @@ mod tests {
             'wrong starter beast for sword'
         );
     }
+
+    fn tranfer_ownership(mut game: IGameDispatcher, from: ContractAddress, to: ContractAddress) {
+        // Some weird conflict when using the game interface ?? using direct ERC721Dispatcher for now. This is not a problem in blockexplorers, I suspect issue in Scarb compiler.
+        IERC721Dispatcher { contract_address: game.contract_address }
+            .transfer_from(from, to, ADVENTURER_ID.into());
+
+        testing::set_contract_address(OWNER_TWO());
+    }
+
+    #[test]
+    fn test_transfered_attack() {
+        let mut game = new_adventurer(364063, 1698678554);
+        tranfer_ownership(game, OWNER(), OWNER_TWO());
+
+        game.attack(ADVENTURER_ID, false);
+    }
+
+
+    #[test]
+    #[should_panic(expected: ('Not authorized to act', 'ENTRYPOINT_FAILED'))]
+    fn test_original_owner_attack() {
+        let mut game = new_adventurer(364063, 1698678554);
+        tranfer_ownership(game, OWNER(), OWNER_TWO());
+
+        testing::set_contract_address(OWNER());
+
+        game.attack(ADVENTURER_ID, false);
+    }
+
+
+    #[test]
+    #[should_panic(expected: ('Not authorized to act', 'ENTRYPOINT_FAILED'))]
+    fn test_original_owner_upgrade() {
+        let mut game = new_adventurer_lvl2(364063, 1698678554, 0);
+        tranfer_ownership(game, OWNER(), OWNER_TWO());
+
+        testing::set_contract_address(OWNER());
+
+        let shopping_cart = ArrayTrait::<ItemPurchase>::new();
+        let stat_upgrades = Stats {
+            strength: 0, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 1, luck: 0
+        };
+        game.upgrade(ADVENTURER_ID, 0, stat_upgrades, shopping_cart.clone());
+    }
+
+    #[test]
+    #[should_panic(expected: ('Not authorized to act', 'ENTRYPOINT_FAILED'))]
+    fn test_original_owner_explore() {
+        let mut game = new_adventurer_lvl2(364063, 1698678554, 0);
+        tranfer_ownership(game, OWNER(), OWNER_TWO());
+
+        let shopping_cart = ArrayTrait::<ItemPurchase>::new();
+        let stat_upgrades = Stats {
+            strength: 0, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 1, luck: 0
+        };
+        game.upgrade(ADVENTURER_ID, 0, stat_upgrades, shopping_cart.clone());
+
+        testing::set_contract_address(OWNER());
+
+        game.explore(ADVENTURER_ID, true);
+    }
+
+    #[test]
+    #[should_panic(expected: ('Not authorized to act', 'ENTRYPOINT_FAILED'))]
+    fn test_original_owner_flee() {
+        let mut game = new_adventurer_lvl2(364063, 1698678554, 0);
+        tranfer_ownership(game, OWNER(), OWNER_TWO());
+
+        let shopping_cart = ArrayTrait::<ItemPurchase>::new();
+        let stat_upgrades = Stats {
+            strength: 0, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 1, luck: 0
+        };
+        game.upgrade(ADVENTURER_ID, 0, stat_upgrades, shopping_cart.clone());
+
+        // go explore
+        game.explore(ADVENTURER_ID, true);
+
+        testing::set_contract_address(OWNER());
+
+        game.flee(ADVENTURER_ID, true);
+    }
+
+
+    #[test]
+    fn test_transfered_upgrade_explore_flee() {
+        let mut game = new_adventurer_lvl2(364063, 1698678554, 0);
+        tranfer_ownership(game, OWNER(), OWNER_TWO());
+
+        let shopping_cart = ArrayTrait::<ItemPurchase>::new();
+        let stat_upgrades = Stats {
+            strength: 0, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 1, luck: 0
+        };
+        game.upgrade(ADVENTURER_ID, 0, stat_upgrades, shopping_cart.clone());
+
+        // go explore
+        game.explore(ADVENTURER_ID, true);
+        game.flee(ADVENTURER_ID, true);
+    }
+
 
     #[starknet::contract]
     mod SnakeERC20Mock {

--- a/contracts/game/src/tests/test_game.cairo
+++ b/contracts/game/src/tests/test_game.cairo
@@ -1913,15 +1913,13 @@ mod tests {
         // Some weird conflict when using the game interface ?? using direct ERC721Dispatcher for now. This is not a problem in blockexplorers, I suspect issue in Scarb compiler.
         IERC721Dispatcher { contract_address: game.contract_address }
             .transfer_from(from, to, ADVENTURER_ID.into());
-
-        testing::set_contract_address(OWNER_TWO());
     }
 
     #[test]
     fn test_transfered_attack() {
         let mut game = new_adventurer(364063, 1698678554);
         transfer_ownership(game, OWNER(), OWNER_TWO());
-
+        testing::set_contract_address(OWNER_TWO());
         game.attack(ADVENTURER_ID, false);
     }
 
@@ -1931,9 +1929,6 @@ mod tests {
     fn test_original_owner_attack() {
         let mut game = new_adventurer(364063, 1698678554);
         transfer_ownership(game, OWNER(), OWNER_TWO());
-
-        testing::set_contract_address(OWNER());
-
         game.attack(ADVENTURER_ID, false);
     }
 
@@ -1943,8 +1938,6 @@ mod tests {
     fn test_original_owner_upgrade() {
         let mut game = new_adventurer_lvl2(364063, 1698678554, 0);
         transfer_ownership(game, OWNER(), OWNER_TWO());
-
-        testing::set_contract_address(OWNER());
 
         let shopping_cart = ArrayTrait::<ItemPurchase>::new();
         let stat_upgrades = Stats {
@@ -1958,6 +1951,7 @@ mod tests {
     fn test_original_owner_explore() {
         let mut game = new_adventurer_lvl2(364063, 1698678554, 0);
         transfer_ownership(game, OWNER(), OWNER_TWO());
+        testing::set_contract_address(OWNER_TWO());
 
         let shopping_cart = ArrayTrait::<ItemPurchase>::new();
         let stat_upgrades = Stats {
@@ -1975,6 +1969,7 @@ mod tests {
     fn test_original_owner_flee() {
         let mut game = new_adventurer_lvl2(364063, 1698678554, 0);
         transfer_ownership(game, OWNER(), OWNER_TWO());
+        testing::set_contract_address(OWNER_TWO());
 
         let shopping_cart = ArrayTrait::<ItemPurchase>::new();
         let stat_upgrades = Stats {
@@ -1995,6 +1990,7 @@ mod tests {
     fn test_transfered_upgrade_explore_flee() {
         let mut game = new_adventurer_lvl2(123, 1696201757, 0);
         transfer_ownership(game, OWNER(), OWNER_TWO());
+        testing::set_contract_address(OWNER_TWO());
 
         let shopping_cart = ArrayTrait::<ItemPurchase>::new();
         let stat_upgrades = Stats {


### PR DESCRIPTION
- adds testing for ERC721 verifing ownership changes when survivors are transfered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a function to facilitate the transfer of ownership in the game, enhancing gameplay dynamics.
	- Added validations to ensure that only the new owner can perform actions post-ownership transfer.

- **Bug Fixes**
	- Enhanced security by preventing the original owner from performing actions after the ownership has been transferred, mitigating unauthorized gameplay.

- **Tests**
	- Comprehensive test cases implemented to validate ownership transfer and its implications on gameplay actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->