### PR TITLE
fixes wrong set length for neck slot

### DIFF
--- a/contracts/adventurer/src/adventurer.cairo
+++ b/contracts/adventurer/src/adventurer.cairo
@@ -3844,7 +3844,6 @@ mod tests {
     }
 
     #[test]
-    #[available_gas(582280)]
     fn test_get_and_apply_stats() {
         let mut adventurer = Adventurer {
             health: 100,
@@ -3860,14 +3859,14 @@ mod tests {
             },
             gold: 40,
             equipment: Equipment {
-                weapon: Item { id: 1, xp: 225 },
-                chest: Item { id: 2, xp: 65535 },
-                head: Item { id: 3, xp: 225 },
-                waist: Item { id: 4, xp: 225 },
-                foot: Item { id: 5, xp: 1000 },
-                hand: Item { id: 6, xp: 224 },
-                neck: Item { id: 7, xp: 1 },
-                ring: Item { id: 8, xp: 1 }
+                weapon: Item { id: ItemId::Wand, xp: 225 },
+                chest: Item { id: ItemId::DivineRobe, xp: 65535 },
+                head: Item { id: ItemId::DivineHood, xp: 225 },
+                waist: Item { id: ItemId::BrightsilkSash, xp: 225 },
+                foot: Item { id: ItemId::DivineSlippers, xp: 1000 },
+                hand: Item { id: ItemId::DivineGloves, xp: 224 },
+                neck: Item { id: ItemId::Amulet, xp: 1 },
+                ring: Item { id: ItemId::GoldRing, xp: 1 }
             },
             beast_health: 20,
             stat_upgrades_available: 0,
@@ -3877,12 +3876,13 @@ mod tests {
         };
 
         let stat_boosts = adventurer.equipment.get_stat_boosts(1);
-        assert(stat_boosts.strength == 6, 'wrong strength');
-        assert(stat_boosts.vitality == 1, 'wrong vitality');
-        assert(stat_boosts.dexterity == 2, 'wrong dexterity');
-        assert(stat_boosts.intelligence == 1, 'wrong intelligence');
-        assert(stat_boosts.wisdom == 4, 'wrong wisdom');
+        assert(stat_boosts.strength == 1, 'wrong strength');
+        assert(stat_boosts.vitality == 2, 'wrong vitality');
+        assert(stat_boosts.dexterity == 4, 'wrong dexterity');
+        assert(stat_boosts.intelligence == 2, 'wrong intelligence');
+        assert(stat_boosts.wisdom == 5, 'wrong wisdom');
         assert(stat_boosts.charisma == 1, 'wrong charisma');
+        assert(stat_boosts.luck == 0, 'wrong luck');
     }
 
     // test base case

--- a/contracts/loot/src/loot.cairo
+++ b/contracts/loot/src/loot.cairo
@@ -764,7 +764,7 @@ impl ImplLoot of ILoot {
             Slot::Waist(()) => ItemSlotLength::SlotItemsLengthWaist,
             Slot::Foot(()) => ItemSlotLength::SlotItemsLengthFoot,
             Slot::Hand(()) => ItemSlotLength::SlotItemsLengthHand,
-            Slot::Neck(()) => ItemSlotLength::SlotItemsLengthHand,
+            Slot::Neck(()) => ItemSlotLength::SlotItemsLengthNeck,
             Slot::Ring(()) => ItemSlotLength::SlotItemsLengthRing,
         }
     }
@@ -1011,7 +1011,7 @@ mod tests {
         loot::{ImplLoot, ILoot, Loot},
         constants::{
             NamePrefixLength, ItemNameSuffix, ItemId, ItemNamePrefix, NameSuffixLength,
-            ItemSuffixLength, ItemSuffix, NUM_ITEMS,
+            ItemSuffixLength, ItemSuffix, NUM_ITEMS,ItemSlotLength
         },
         utils::{
             NameUtils::{
@@ -3657,5 +3657,60 @@ mod tests {
         assert(item.tier == Tier::None(()), 'item is tier none');
         assert(item.slot == Slot::None(()), 'item is slot none');
         assert(item.item_type == Type::None(()), 'item is type none');
+    }
+
+    #[test]
+    fn test_get_slot_length() {
+        // None
+        assert(ImplLoot::get_slot_length(Slot::None(())) == 0, 'None slot should return 0');
+
+        // Weapon
+        assert(
+            ImplLoot::get_slot_length(Slot::Weapon(())) == ItemSlotLength::SlotItemsLengthWeapon,
+            'Incorrect weapon slot length'
+        );
+
+        // Chest
+        assert(
+            ImplLoot::get_slot_length(Slot::Chest(())) == ItemSlotLength::SlotItemsLengthChest,
+            'Incorrect chest slot length'
+        );
+
+        // Head
+        assert(
+            ImplLoot::get_slot_length(Slot::Head(())) == ItemSlotLength::SlotItemsLengthHead,
+            'Incorrect head slot length'
+        );
+
+        // Waist
+        assert(
+            ImplLoot::get_slot_length(Slot::Waist(())) == ItemSlotLength::SlotItemsLengthWaist,
+            'Incorrect waist slot length'
+        );
+
+        // Foot
+        assert(
+            ImplLoot::get_slot_length(Slot::Foot(())) == ItemSlotLength::SlotItemsLengthFoot,
+            'Incorrect foot slot length'
+        );
+
+        // Hand
+        assert(
+            ImplLoot::get_slot_length(Slot::Hand(())) == ItemSlotLength::SlotItemsLengthHand,
+            'Incorrect hand slot length'
+        );
+
+        // Neck
+        assert(
+            ImplLoot::get_slot_length(Slot::Neck(())) == ItemSlotLength::SlotItemsLengthNeck,
+            'Incorrect neck slot length'
+        );
+
+        // Ring
+        assert(
+            ImplLoot::get_slot_length(Slot::Ring(())) == ItemSlotLength::SlotItemsLengthRing,
+            'Incorrect ring slot length'
+        );
+
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
  - Corrected the mapping for the neck slot to ensure accurate item slot length retrieval.

- **New Features**
  - Introduced a test function to validate retrieval of slot lengths for various item slots, enhancing overall test coverage.
  - Added a new test function to validate the uniqueness of market items generated based on the seed and offset.

- **Improvements**
  - Enhanced combat mechanics by refining randomness handling in critical hits and attacks.
  - Adjusted equipment items for adventurers to improve type safety and clarity.
  - Revised stat boost calculations for adventurers to improve game balance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->