### PR TITLE
add free_game endpoint for launch promotion

### DIFF
--- a/contracts/game/src/game/constants.cairo
+++ b/contracts/game/src/game/constants.cairo
@@ -64,6 +64,11 @@ mod messages {
     const OBITUARY_ALREADY_SET: felt252 = 'obituary already set';
     const OBITUARY_WINDOW_CLOSED: felt252 = 'obituary window closed';
     const INVALID_ITEM_ID: felt252 = 'invalid item id';
+    const LAUNCH_PROMOTION_CLOSED: felt252 = 'launch promotion closed';
+    const NFT_COLLECTION_NOT_ELIGIBLE: felt252 = 'nft collection not eligible';
+    const NOT_TOKEN_OWNER: felt252 = 'not token owner';
+    const TOKEN_ALREADY_CLAIMED: felt252 = 'token already claimed';
+
 }
 
 #[derive(Drop, Copy)]

--- a/contracts/game/src/game/interfaces.cairo
+++ b/contracts/game/src/game/interfaces.cairo
@@ -52,6 +52,15 @@ trait IGame<TContractState> {
     );
     fn slay_expired_adventurers(ref self: TContractState, adventurer_ids: Array<felt252>);
 
+    fn claim_free_game(
+        ref self: TContractState,
+        weapon: u8,
+        name: felt252,
+        custom_renderer: ContractAddress,
+        delay_stat_reveal: bool,
+        nft_address: ContractAddress,
+        token_id: u256
+    );
     // ------ View Functions ------
 
     // adventurer details

--- a/contracts/game/src/tests/test_game.cairo
+++ b/contracts/game/src/tests/test_game.cairo
@@ -88,6 +88,18 @@ mod tests {
         contract_address_const::<1>()
     }
 
+    fn QUALIFYING_COLLECTIONS() -> Span<ContractAddress> {
+        let mut qualifying_collections = ArrayTrait::<ContractAddress>::new();
+        qualifying_collections.append(contract_address_const::<1>());
+        qualifying_collections.append(contract_address_const::<2>());
+        qualifying_collections.append(contract_address_const::<3>());
+        qualifying_collections.span()
+    }
+
+    fn LAUNCH_PROMOTION_END_TIMESTAMP() -> u64 {
+        0
+    }
+
     fn ZERO_ADDRESS() -> ContractAddress {
         contract_address_const::<0>()
     }
@@ -176,10 +188,9 @@ mod tests {
         lords: ContractAddress,
         eth: ContractAddress,
         golden_token: ContractAddress,
-        terminal_block: u64,
+        terminal_timestamp: u64,
         randomness: ContractAddress
     ) -> IGameDispatcher {
-        let vrf_level_interval = 3;
         let mut calldata = ArrayTrait::<felt252>::new();
         calldata.append(lords.into());
         calldata.append(eth.into());
@@ -187,12 +198,25 @@ mod tests {
         calldata.append(PG().into());
         calldata.append(COLLECTIBLE_BEASTS().into());
         calldata.append(golden_token.into());
-        calldata.append(terminal_block.into());
+        calldata.append(terminal_timestamp.into());
         calldata.append(randomness.into());
-        calldata.append(vrf_level_interval);
         calldata.append(ORACLE_ADDRESS().into());
         calldata.append(RENDER_CONTRACT().into());
+        calldata.append(0);
+        // TODO: add qualifying collections at deployment so we can properly
+        // test
+        // let mut qualifying_collections = QUALIFYING_COLLECTIONS();
+        // loop {
+        //     match qualifying_collections.pop_front() {
+        //         Option::Some(collection) => { 
+        //             let collection = *collection; 
+        //             calldata.append(collection.into()); 
+        //         },
+        //         Option::None(_) => { break; }
+        //     };
+        // };
 
+        calldata.append(LAUNCH_PROMOTION_END_TIMESTAMP().into());
         IGameDispatcher { contract_address: utils::deploy(Game::TEST_CLASS_HASH, calldata) }
     }
 


### PR DESCRIPTION
- adds a 'qualifying_collections'  array<ContractAddress> to the constructor
- adds an external `claim_free_game` that takes in `new_game` parameters along with an nft_address and token_id
- `claim_free_game` verifies the launch promotion is available, the provided nft is part of the promotion, the caller owns the token, that the token has not been claimed.
- If the above criteria has been met, it sets token as claimed and mints a new game

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced new error message constants for improved user feedback related to game conditions.
	- Added a new function to claim a free game, enhancing player engagement and resource management through NFT ownership verification.
	- Expanded game state functionality to track promotional periods and qualifying NFT collections, integrating NFT mechanics into gameplay.

- **Bug Fixes**
	- Enhanced error handling for various game conditions to provide clearer feedback to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->