### PR TITLE
adds `get_item_specials(adventurer_id)` view function

### DIFF
--- a/contracts/adventurer/src/adventurer.cairo
+++ b/contracts/adventurer/src/adventurer.cairo
@@ -12,6 +12,7 @@ use loot::{
     loot::{Loot, ILoot, ImplLoot},
     constants::{
         ItemSuffix, ItemId, NamePrefixLength, NameSuffixLength, SUFFIX_UNLOCK_GREATNESS,
+        PREFIXES_UNLOCK_GREATNESS,
         ItemSuffix::{
             of_Power, of_Giant, of_Titans, of_Skill, of_Perfection, of_Brilliance, of_Enlightenment,
             of_Protection, of_Anger, of_Rage, of_Fury, of_Vitriol, of_the_Fox, of_Detection,
@@ -57,6 +58,22 @@ struct Adventurer {
     battle_action_count: u8, // 8 bits
     mutated: bool, // not packed
     awaiting_item_specials: bool, // not packed
+}
+
+#[derive(Drop, Serde)]
+struct ItemLeveledUp {
+    item_id: u8,
+    previous_level: u8,
+    new_level: u8,
+    suffix_unlocked: bool,
+    prefixes_unlocked: bool,
+    specials: SpecialPowers
+}
+
+#[derive(Drop, Serde)]
+struct ItemSpecial {
+    item_id: u8,
+    special_power: SpecialPowers
 }
 
 /// @title Adventurer Packing
@@ -1176,6 +1193,153 @@ impl ImplAdventurer of IAdventurer {
         hash_span.append(adventurer_xp.into());
         hash_span.append(adventurer_id);
         poseidon_hash_span(hash_span.span()).into()
+    }
+
+    /// @notice Generates item leveled up events
+    /// @param equipment: adventurer equipment
+    /// @param seed: seed for randomness
+    /// @return Array<ItemSpecial>: array of item specials
+    /// @dev this function is used immediately after receiving item specials entropy from VRF to let the client know the specials of the items that triggered the specials
+    fn get_items_leveled_up(equipment: Equipment, seed: u16,) -> Array<ItemLeveledUp> {
+        let mut items_leveled_up = ArrayTrait::<ItemLeveledUp>::new();
+        let weapon_level = ImplCombat::get_level_from_xp(equipment.weapon.xp);
+        if weapon_level >= SUFFIX_UNLOCK_GREATNESS {
+            let weapon_id = equipment.weapon.id;
+            let weapon_leveled_up_event = ItemLeveledUp {
+                item_id: weapon_id,
+                previous_level: weapon_level,
+                new_level: weapon_level,
+                suffix_unlocked: true,
+                prefixes_unlocked: weapon_level > PREFIXES_UNLOCK_GREATNESS,
+                specials: SpecialPowers {
+                    special1: ImplLoot::get_suffix(weapon_id, seed),
+                    special2: ImplLoot::get_prefix1(weapon_id, seed),
+                    special3: ImplLoot::get_prefix2(weapon_id, seed),
+                },
+            };
+
+            items_leveled_up.append(weapon_leveled_up_event);
+        }
+        let chest_level = ImplCombat::get_level_from_xp(equipment.chest.xp);
+        if chest_level >= SUFFIX_UNLOCK_GREATNESS {
+            let chest_id = equipment.chest.id;
+            let chest_leveled_up_event = ItemLeveledUp {
+                item_id: chest_id,
+                previous_level: chest_level,
+                new_level: chest_level,
+                suffix_unlocked: true,
+                prefixes_unlocked: chest_level > PREFIXES_UNLOCK_GREATNESS,
+                specials: SpecialPowers {
+                    special1: ImplLoot::get_suffix(chest_id, seed),
+                    special2: ImplLoot::get_prefix1(chest_id, seed),
+                    special3: ImplLoot::get_prefix2(chest_id, seed),
+                },
+            };
+            items_leveled_up.append(chest_leveled_up_event);
+        }
+        let head_level = ImplCombat::get_level_from_xp(equipment.head.xp);
+        if head_level >= SUFFIX_UNLOCK_GREATNESS {
+            let head_id = equipment.head.id;
+            let head_leveled_up_event = ItemLeveledUp {
+                item_id: head_id,
+                previous_level: head_level,
+                new_level: head_level,
+                suffix_unlocked: true,
+                prefixes_unlocked: head_level > PREFIXES_UNLOCK_GREATNESS,
+                specials: SpecialPowers {
+                    special1: ImplLoot::get_suffix(head_id, seed),
+                    special2: ImplLoot::get_prefix1(head_id, seed),
+                    special3: ImplLoot::get_prefix2(head_id, seed),
+                },
+            };
+            items_leveled_up.append(head_leveled_up_event);
+        }
+        let waist_level = ImplCombat::get_level_from_xp(equipment.waist.xp);
+        if waist_level >= SUFFIX_UNLOCK_GREATNESS {
+            let waist_id = equipment.waist.id;
+            let waist_leveled_up_event = ItemLeveledUp {
+                item_id: waist_id,
+                previous_level: waist_level,
+                new_level: waist_level,
+                suffix_unlocked: true,
+                prefixes_unlocked: waist_level > PREFIXES_UNLOCK_GREATNESS,
+                specials: SpecialPowers {
+                    special1: ImplLoot::get_suffix(waist_id, seed),
+                    special2: ImplLoot::get_prefix1(waist_id, seed),
+                    special3: ImplLoot::get_prefix2(waist_id, seed),
+                },
+            };
+            items_leveled_up.append(waist_leveled_up_event);
+        }
+        let foot_level = ImplCombat::get_level_from_xp(equipment.foot.xp);
+        if foot_level >= SUFFIX_UNLOCK_GREATNESS {
+            let foot_id = equipment.foot.id;
+            let foot_leveled_up_event = ItemLeveledUp {
+                item_id: foot_id,
+                previous_level: foot_level,
+                new_level: foot_level,
+                suffix_unlocked: true,
+                prefixes_unlocked: foot_level > PREFIXES_UNLOCK_GREATNESS,
+                specials: SpecialPowers {
+                    special1: ImplLoot::get_suffix(foot_id, seed),
+                    special2: ImplLoot::get_prefix1(foot_id, seed),
+                    special3: ImplLoot::get_prefix2(foot_id, seed),
+                },
+            };
+            items_leveled_up.append(foot_leveled_up_event);
+        }
+        let hand_level = ImplCombat::get_level_from_xp(equipment.hand.xp);
+        if hand_level >= SUFFIX_UNLOCK_GREATNESS {
+            let hand_id = equipment.hand.id;
+            let hand_leveled_up_event = ItemLeveledUp {
+                item_id: hand_id,
+                previous_level: hand_level,
+                new_level: hand_level,
+                suffix_unlocked: true,
+                prefixes_unlocked: hand_level > PREFIXES_UNLOCK_GREATNESS,
+                specials: SpecialPowers {
+                    special1: ImplLoot::get_suffix(hand_id, seed),
+                    special2: ImplLoot::get_prefix1(hand_id, seed),
+                    special3: ImplLoot::get_prefix2(hand_id, seed),
+                },
+            };
+            items_leveled_up.append(hand_leveled_up_event);
+        }
+        let neck_level = ImplCombat::get_level_from_xp(equipment.neck.xp);
+        if neck_level >= SUFFIX_UNLOCK_GREATNESS {
+            let neck_id = equipment.neck.id;
+            let neck_leveled_up_event = ItemLeveledUp {
+                item_id: neck_id,
+                previous_level: neck_level,
+                new_level: neck_level,
+                suffix_unlocked: true,
+                prefixes_unlocked: neck_level > PREFIXES_UNLOCK_GREATNESS,
+                specials: SpecialPowers {
+                    special1: ImplLoot::get_suffix(neck_id, seed),
+                    special2: ImplLoot::get_prefix1(neck_id, seed),
+                    special3: ImplLoot::get_prefix2(neck_id, seed),
+                },
+            };
+            items_leveled_up.append(neck_leveled_up_event);
+        }
+        let ring_level = ImplCombat::get_level_from_xp(equipment.ring.xp);
+        if ring_level >= SUFFIX_UNLOCK_GREATNESS {
+            let ring_id = equipment.ring.id;
+            let ring_leveled_up_event = ItemLeveledUp {
+                item_id: ring_id,
+                previous_level: ring_level,
+                new_level: ring_level,
+                suffix_unlocked: true,
+                prefixes_unlocked: ring_level > PREFIXES_UNLOCK_GREATNESS,
+                specials: SpecialPowers {
+                    special1: ImplLoot::get_suffix(ring_id, seed),
+                    special2: ImplLoot::get_prefix1(ring_id, seed),
+                    special3: ImplLoot::get_prefix2(ring_id, seed),
+                },
+            };
+            items_leveled_up.append(ring_leveled_up_event);
+        }
+        items_leveled_up
     }
 }
 

--- a/contracts/game/src/game/constants.cairo
+++ b/contracts/game/src/game/constants.cairo
@@ -68,7 +68,7 @@ mod messages {
     const NFT_COLLECTION_NOT_ELIGIBLE: felt252 = 'nft collection not eligible';
     const NOT_TOKEN_OWNER: felt252 = 'not token owner';
     const TOKEN_ALREADY_CLAIMED: felt252 = 'token already claimed';
-
+    const ITEM_SPECIALS_UNAVAILABLE: felt252 = 'item specials unavailable';
 }
 
 #[derive(Drop, Copy)]

--- a/contracts/game/src/game/interfaces.cairo
+++ b/contracts/game/src/game/interfaces.cairo
@@ -3,7 +3,7 @@ use starknet::ContractAddress;
 use beasts::beast::Beast;
 use market::market::{ItemPurchase};
 use adventurer::{
-    bag::Bag, adventurer::{Adventurer, Stats}, adventurer_meta::AdventurerMetadata,
+    bag::Bag, adventurer::{Adventurer, Stats, ItemSpecial}, adventurer_meta::AdventurerMetadata,
     leaderboard::Leaderboard, item::{Item},
     constants::discovery_constants::DiscoveryEnums::ExploreResult
 };
@@ -82,6 +82,7 @@ trait IGame<TContractState> {
 
     // beast details
     fn get_attacking_beast(self: @TContractState, adventurer_id: felt252) -> Beast;
+    fn get_item_specials(self: @TContractState, adventurer_id: felt252) -> Array<ItemSpecial>;
     // fn get_beast_type(self: @TContractState, beast_id: u8) -> u8;
     // fn get_beast_tier(self: @TContractState, beast_id: u8) -> u8;
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -19,7 +19,8 @@ interface_camel=0
 vrf_fee_limit=5000000000000000
 eth_contract=0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
 custom_renderer=0x0
-
+qualifying_collections="3 0x07c006181ea9cc7dd1b09c29e9ff23112be30ecfef73b760fabe5bc7ae6ecb44 0x04efe851716110abeee81b7f22f7964845355ffa32e6833fc3a557a1881721ac 0x04a79a62dc260f2e9e4b208181b2014c14f3ff44fe7d0e6452a759ed91a106d1"
+launch_promotion_end_timestamp=1723835867
 # Source env vars
 ENV_FILE="/workspaces/loot-survivor/.env"
 source $ENV_FILE
@@ -38,11 +39,11 @@ game_class_hash=$(starkli declare --watch /workspaces/loot-survivor/target/dev/g
 renderer_contract=$(starkli deploy --watch $renderer_class_hash --account $STARKNET_ACCOUNT --private-key $PRIVATE_KEY --max-fee 0.01 2>/dev/null)
 
 # deploy game
-game_contract=$(starkli deploy --watch $game_class_hash $lords_contract $eth_contract $dao_address $pg_address $beasts_address $golden_token_address $terminal_timestamp $randomness_contract $randomness_rotation_interval $oracle_address $renderer_contract --account $STARKNET_ACCOUNT --private-key $PRIVATE_KEY --max-fee 0.01 2>/dev/null)
+game_contract=$(starkli deploy --watch $game_class_hash $lords_contract $eth_contract $dao_address $pg_address $beasts_address $golden_token_address $terminal_timestamp $randomness_contract $oracle_address $renderer_contract $qualifying_collections $launch_promotion_end_timestamp --account $STARKNET_ACCOUNT --private-key $PRIVATE_KEY --max-fee 0.01 2>/dev/null)
 
 # mint lords
 echo "minting lords"
-starkli invoke --watch $lords_contract mint $ACCOUNT_ADDRESS 1000000000000000000000 0 --account $STARKNET_ACCOUNT --private-key $PRIVATE_KEY --max-fee 0.01 2>/dev/null
+starkli invoke --watch $lords_contract mint_lords $ACCOUNT_ADDRESS 1000000000000000000000 0 --account $STARKNET_ACCOUNT --private-key $PRIVATE_KEY --max-fee 0.01 2>/dev/null
 
 # give game contract approval to spent lords
 echo "approving game contract to spend lords"


### PR DESCRIPTION
- if item specials seed has not been reached, which happens when first item reaches g15, the view function will return an error
- the view function will return the specials for all 101 items so clients can make a single RPC call to get all specials once the item specials entropy is available
- this PR also prevents item specials seed from being set to 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new structures for item leveling and special powers, enhancing item management.
	- Added functionality to retrieve leveled-up items and their special powers for adventurers.
	- Implemented a new messaging constant for scenarios when item specials are unavailable.
	- Enhanced game mechanics with new capabilities related to adventurer inventory and item specials.

- **Bug Fixes**
	- Adjusted the logic for handling item specials and leveling to improve game robustness.

- **Chores**
	- Updated deployment scripts with new parameters for qualifying collections and promotional timing adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->