### PR TITLE
store client provider address and golden token id (closes #132)

### DIFF
--- a/contracts/adventurer/src/adventurer_meta.cairo
+++ b/contracts/adventurer/src/adventurer_meta.cairo
@@ -8,6 +8,7 @@ struct AdventurerMetadata {
     item_specials_seed: u16, // 16 bits in storage
     rank_at_death: u8, // 2 bits in storage
     delay_stat_reveal: bool, // 1 bit in storage
+    golden_token_id: u8, // 8 bits in storage
 }
 
 impl PackingAdventurerMetadata of StorePacking<AdventurerMetadata, felt252> {
@@ -26,7 +27,8 @@ impl PackingAdventurerMetadata of StorePacking<AdventurerMetadata, felt252> {
             + value.level_seed.into() * TWO_POW_128
             + value.item_specials_seed.into() * TWO_POW_192
             + value.rank_at_death.into() * TWO_POW_208
-            + delay_stat_reveal * TWO_POW_210)
+            + delay_stat_reveal * TWO_POW_210
+            + value.golden_token_id.into() * TWO_POW_211)
             .try_into()
             .unwrap()
     }
@@ -42,7 +44,8 @@ impl PackingAdventurerMetadata of StorePacking<AdventurerMetadata, felt252> {
         let (packed, level_seed) = integer::U256DivRem::div_rem(packed, TWO_POW_64_NZ);
         let (packed, item_specials_seed) = integer::U256DivRem::div_rem(packed, TWO_POW_16_NZ);
         let (packed, rank_at_death) = integer::U256DivRem::div_rem(packed, TWO_POW_2_NZ);
-        let (_, delay_stat_reveal_u256) = integer::U256DivRem::div_rem(packed, TWO_POW_1_NZ);
+        let (packed, delay_stat_reveal_u256) = integer::U256DivRem::div_rem(packed, TWO_POW_1_NZ);
+        let (_, golden_token_id) = integer::U256DivRem::div_rem(packed, TWO_POW_8_NZ);
 
         let birth_date = birth_date.try_into().unwrap();
         let death_date = death_date.try_into().unwrap();
@@ -50,9 +53,10 @@ impl PackingAdventurerMetadata of StorePacking<AdventurerMetadata, felt252> {
         let delay_stat_reveal = delay_stat_reveal_u256 != 0;
         let rank_at_death = rank_at_death.try_into().unwrap();
         let item_specials_seed = item_specials_seed.try_into().unwrap();
+        let golden_token_id = golden_token_id.try_into().unwrap();
 
         AdventurerMetadata {
-            birth_date, death_date, level_seed, item_specials_seed, rank_at_death, delay_stat_reveal
+            birth_date, death_date, level_seed, item_specials_seed, rank_at_death, delay_stat_reveal, golden_token_id
         }
     }
 }
@@ -63,15 +67,17 @@ impl ImplAdventurerMetadata of IAdventurerMetadata {
     /// @dev: AdventurerMetadata is initialized without any starting stats
     /// @param birth_date: The start time of the adventurer
     /// @param delay_reveal: Whether the adventurer should delay reveal
+    /// @param golden_token_id: The golden token id of the adventurer
     /// @return: The newly created AdventurerMetadata struct
-    fn new(birth_date: u64, delay_stat_reveal: bool) -> AdventurerMetadata {
+    fn new(birth_date: u64, delay_stat_reveal: bool, golden_token_id: u8) -> AdventurerMetadata {
         AdventurerMetadata {
             birth_date,
             death_date: 0,
             level_seed: 0,
             item_specials_seed: 0,
             rank_at_death: 0,
-            delay_stat_reveal
+            delay_stat_reveal,
+            golden_token_id,
         }
     }
 }
@@ -79,6 +85,7 @@ impl ImplAdventurerMetadata of IAdventurerMetadata {
 const TWO_POW_1: u256 = 0x2;
 const TWO_POW_2_NZ: NonZero<u256> = 0x4;
 const TWO_POW_1_NZ: NonZero<u256> = 0x2;
+const TWO_POW_8_NZ: NonZero<u256> = 0x100;
 const TWO_POW_16: u256 = 0x10000;
 const TWO_POW_16_NZ: NonZero<u256> = 0x10000;
 const TWO_POW_64: u256 = 0x10000000000000000;
@@ -87,6 +94,8 @@ const TWO_POW_128: u256 = 0x100000000000000000000000000000000;
 const TWO_POW_192: u256 = 0x1000000000000000000000000000000000000000000000000;
 const TWO_POW_208: u256 = 0x10000000000000000000000000000000000000000000000000000;
 const TWO_POW_210: u256 = 0x40000000000000000000000000000000000000000000000000000;
+const TWO_POW_211: u256 = 0x80000000000000000000000000000000000000000000000000000;
+
 // ---------------------------
 // ---------- Tests ----------
 // ---------------------------
@@ -96,6 +105,7 @@ mod tests {
     const U64_MAX: u64 = 0xffffffffffffffff;
     const U16_MAX: u16 = 0xffff;
     const U2_MAX: u8 = 0x3;
+    const U8_MAX: u8 = 0xff;
 
     #[test]
     fn test_adventurer_metadata_packing() {
@@ -107,6 +117,7 @@ mod tests {
             item_specials_seed: U16_MAX,
             rank_at_death: U2_MAX,
             delay_stat_reveal: true,
+            golden_token_id: U8_MAX,
         };
         let packed = PackingAdventurerMetadata::pack(meta);
         let unpacked: AdventurerMetadata = PackingAdventurerMetadata::unpack(packed);
@@ -119,6 +130,7 @@ mod tests {
         );
         assert(meta.rank_at_death == unpacked.rank_at_death, 'rank at death should be max u2');
         assert(meta.delay_stat_reveal == unpacked.delay_stat_reveal, 'delay reveal should be true');
+        assert(meta.golden_token_id == unpacked.golden_token_id, 'golden token should be max');
 
         // zero case
         let meta = AdventurerMetadata {
@@ -127,7 +139,8 @@ mod tests {
             level_seed: 0,
             item_specials_seed: 0,
             rank_at_death: 0,
-            delay_stat_reveal: false
+            delay_stat_reveal: false,
+            golden_token_id: 0,
         };
         let packed = PackingAdventurerMetadata::pack(meta);
         let unpacked: AdventurerMetadata = PackingAdventurerMetadata::unpack(packed);
@@ -137,17 +150,19 @@ mod tests {
         assert(unpacked.item_specials_seed == 0, 'item specials seed should be 0');
         assert(unpacked.rank_at_death == 0, 'rank at death should be 0');
         assert(unpacked.delay_stat_reveal == false, 'delay reveal should be false');
+        assert(unpacked.golden_token_id == 0, 'golden token id should be 0');
     }
 
     #[test]
     fn test_new_adventurer_metadata() {
         let birthdate = 12345;
-        let meta = ImplAdventurerMetadata::new(birthdate, false);
+        let meta = ImplAdventurerMetadata::new(birthdate, false, 0);
         assert(meta.birth_date == birthdate, 'start time should be 12345');
         assert(meta.death_date == 0, 'end time should be 0');
         assert(meta.level_seed == 0, 'level seed should be 0');
         assert(meta.item_specials_seed == 0, 'item specials seed should be 0');
         assert(meta.rank_at_death == 0, 'rank at death should be 0');
         assert(meta.delay_stat_reveal == false, 'delay reveal should be false');
+        assert(meta.golden_token_id == 0, 'golden token id should be 0');
     }
 }

--- a/contracts/game/src/game/interfaces.cairo
+++ b/contracts/game/src/game/interfaces.cairo
@@ -68,6 +68,7 @@ trait IGame<TContractState> {
     fn get_adventurer_obituary(self: @TContractState, adventurer_id: felt252) -> ByteArray;
     fn get_adventurer_no_boosts(self: @TContractState, adventurer_id: felt252) -> Adventurer;
     fn get_adventurer_meta(self: @TContractState, adventurer_id: felt252) -> AdventurerMetadata;
+    fn get_client_provider(self: @TContractState, adventurer_id: felt252) -> ContractAddress;
 
     // fn equipment_stat_boosts(self: @TContractState, adventurer_id: felt252) -> Stats;
 

--- a/contracts/game/src/game/renderer.cairo
+++ b/contracts/game/src/game/renderer.cairo
@@ -92,7 +92,7 @@ fn create_text(
     baseline: ByteArray,
     text_anchor: ByteArray,
 ) -> ByteArray {
-        "<text x='"
+    "<text x='"
         + x
         + "' y='"
         + y
@@ -108,7 +108,7 @@ fn create_text(
 }
 
 fn create_item_element(x: ByteArray, y: ByteArray, item: ByteArray) -> ByteArray {
-        "<g transform='translate(" + x + "," + y + ") scale(1.5)'>" + item + "</g>"
+    "<g transform='translate(" + x + "," + y + ") scale(1.5)'>" + item + "</g>"
 }
 
 // @notice Combines elements into a single string
@@ -136,7 +136,9 @@ fn combine_elements(ref elements: Span<ByteArray>) -> ByteArray {
 // @param internals The internals of the SVG
 // @return The generated SVG string
 fn create_svg(internals: ByteArray) -> ByteArray {
-    "<svg xmlns='http://www.w3.org/2000/svg' width='600' height='900'><style>text{text-transform: uppercase;font-family: Courier, monospace;fill: #3DEC00;}g{fill: #3DEC00;}</style>" + internals + "</svg>"
+    "<svg xmlns='http://www.w3.org/2000/svg' width='600' height='900'><style>text{text-transform: uppercase;font-family: Courier, monospace;fill: #3DEC00;}g{fill: #3DEC00;}</style>"
+        + internals
+        + "</svg>"
 }
 
 // @notice Generates a suffix boost string for adventurer token uri
@@ -277,19 +279,48 @@ fn create_metadata(
     let _current_rank = format!("{}", current_rank);
 
     let _gold = format!("{}", adventurer.gold);
-    let _str = if adventurer.get_level() == 1 { "?" } else { format!("{}", adventurer.stats.strength) };
-    let _dex = if adventurer.get_level() == 1 { "?" } else { format!("{}", adventurer.stats.dexterity) };
-    let _int = if adventurer.get_level() == 1 { "?" } else { format!("{}", adventurer.stats.intelligence) };
-    let _vit = if adventurer.get_level() == 1 { "?" } else { format!("{}", adventurer.stats.vitality) };
-    let _wis = if adventurer.get_level() == 1 { "?" } else { format!("{}", adventurer.stats.wisdom) };
-    let _cha = if adventurer.get_level() == 1 { "?" } else { format!("{}", adventurer.stats.charisma) };
+    let _str = if adventurer.get_level() == 1 {
+        "?"
+    } else {
+        format!("{}", adventurer.stats.strength)
+    };
+    let _dex = if adventurer.get_level() == 1 {
+        "?"
+    } else {
+        format!("{}", adventurer.stats.dexterity)
+    };
+    let _int = if adventurer.get_level() == 1 {
+        "?"
+    } else {
+        format!("{}", adventurer.stats.intelligence)
+    };
+    let _vit = if adventurer.get_level() == 1 {
+        "?"
+    } else {
+        format!("{}", adventurer.stats.vitality)
+    };
+    let _wis = if adventurer.get_level() == 1 {
+        "?"
+    } else {
+        format!("{}", adventurer.stats.wisdom)
+    };
+    let _cha = if adventurer.get_level() == 1 {
+        "?"
+    } else {
+        format!("{}", adventurer.stats.charisma)
+    };
     let _luck = format!("{}", adventurer.stats.luck);
 
     let _timestamp = starknet::get_block_info().unbox().block_timestamp;
     let _game_expiry_days: u8 = 10;
     let _seconds_in_day: u32 = 86400;
-    let _game_expiry_seconds = adventurerMetadata.birth_date + (_game_expiry_days.into() * _seconds_in_day.into());
-    let _seconds_left = if _timestamp > _game_expiry_seconds { 0 } else { _game_expiry_seconds - _timestamp };
+    let _game_expiry_seconds = adventurerMetadata.birth_date
+        + (_game_expiry_days.into() * _seconds_in_day.into());
+    let _seconds_left = if _timestamp > _game_expiry_seconds {
+        0
+    } else {
+        _game_expiry_seconds - _timestamp
+    };
     let _hours_left = format!("{}", _seconds_left / 3600);
 
     // Equipped items
@@ -404,7 +435,10 @@ fn create_metadata(
     let wis: ByteArray = JsonImpl::new().add("trait", "Wisdom").add("value", _wis).build();
     let cha: ByteArray = JsonImpl::new().add("trait", "Charisma").add("value", _cha).build();
     let luck: ByteArray = JsonImpl::new().add("trait", "Luck").add("value", _luck).build();
-    let hours_left: ByteArray = JsonImpl::new().add("trait", "Hours Left").add("value", _hours_left).build();
+    let hours_left: ByteArray = JsonImpl::new()
+        .add("trait", "Hours Left")
+        .add("value", _hours_left)
+        .build();
 
     let equipped_weapon: ByteArray = JsonImpl::new()
         .add("trait", "Weapon")
@@ -493,14 +527,19 @@ mod tests {
     use snforge_std::{start_cheat_block_timestamp_global};
 
 
-
     #[test]
     fn test_metadata() {
         let adventurer = Adventurer {
             health: 1023,
             xp: 10000,
             stats: Stats {
-                strength: 10, dexterity: 50, vitality: 50, intelligence: 50, wisdom: 50, charisma: 50, luck: 100
+                strength: 10,
+                dexterity: 50,
+                vitality: 50,
+                intelligence: 50,
+                wisdom: 50,
+                charisma: 50,
+                luck: 100
             },
             gold: 1023,
             equipment: Equipment {
@@ -542,23 +581,86 @@ mod tests {
         let birth_date = 1421807737;
         let delay_stat_reveal = false;
 
-        let adventurer_metadata = ImplAdventurerMetadata::new(birth_date, delay_stat_reveal);
+        let adventurer_metadata = ImplAdventurerMetadata::new(birth_date, delay_stat_reveal, 0);
 
         start_cheat_block_timestamp_global(1721860860);
 
-        let current_1 = create_metadata(1000000, adventurer, 'thisisareallyreallyreallongname', adventurer_metadata, bag, 10, 1, 1);
+        let current_1 = create_metadata(
+            1000000,
+            adventurer,
+            'thisisareallyreallyreallongname',
+            adventurer_metadata,
+            bag,
+            10,
+            1,
+            1
+        );
 
-        let current_2 = create_metadata(1000000, adventurer, 'thisisareallyreallyreallongname', adventurer_metadata, bag, 10, 2, 2);
+        let current_2 = create_metadata(
+            1000000,
+            adventurer,
+            'thisisareallyreallyreallongname',
+            adventurer_metadata,
+            bag,
+            10,
+            2,
+            2
+        );
 
-        let current_3 = create_metadata(1000000, adventurer, 'thisisareallyreallyreallongname', adventurer_metadata, bag, 10, 3, 3);
+        let current_3 = create_metadata(
+            1000000,
+            adventurer,
+            'thisisareallyreallyreallongname',
+            adventurer_metadata,
+            bag,
+            10,
+            3,
+            3
+        );
 
-        let historical_1 = create_metadata(1000000, adventurer, 'thisisareallyreallyreallongname', adventurer_metadata, bag, 10, 1, 0);
+        let historical_1 = create_metadata(
+            1000000,
+            adventurer,
+            'thisisareallyreallyreallongname',
+            adventurer_metadata,
+            bag,
+            10,
+            1,
+            0
+        );
 
-        let historical_2 = create_metadata(1000000, adventurer, 'thisisareallyreallyreallongname', adventurer_metadata, bag, 10, 2, 0);
+        let historical_2 = create_metadata(
+            1000000,
+            adventurer,
+            'thisisareallyreallyreallongname',
+            adventurer_metadata,
+            bag,
+            10,
+            2,
+            0
+        );
 
-        let historical_3 = create_metadata(1000000, adventurer, 'thisisareallyreallyreallongname', adventurer_metadata, bag, 10, 3, 0);
+        let historical_3 = create_metadata(
+            1000000,
+            adventurer,
+            'thisisareallyreallyreallongname',
+            adventurer_metadata,
+            bag,
+            10,
+            3,
+            0
+        );
 
-        let plain = create_metadata(1000000, adventurer, 'thisisareallyreallyreallongname', adventurer_metadata, bag, 10, 0, 0);
+        let plain = create_metadata(
+            1000000,
+            adventurer,
+            'thisisareallyreallyreallongname',
+            adventurer_metadata,
+            bag,
+            10,
+            0,
+            0
+        );
 
         println!("Current 1: {}", current_1);
         println!("Current 2: {}", current_2);

--- a/contracts/game/src/tests/test_game.cairo
+++ b/contracts/game/src/tests/test_game.cairo
@@ -2746,4 +2746,28 @@ mod tests {
                 game.contract_address, VRF_PREMIUMS_ADDRESS(), 10000000000000000000000000000000
             );
     }
+
+    #[test]
+    fn test_record_client_provider_address() {
+        let (mut game, _, _, _, _, _, _) = deploy_game(0, 0, 0, 0);
+        let player1 = add_adventurer_to_game(ref game, 0, ItemId::Wand);
+        // get adventurer metadata
+        let client_provider_address = game.get_client_provider(player1);
+        assert(client_provider_address == INTERFACE_ID(), 'wrong client provider address');
+    }
+
+    #[test]
+    fn test_golden_token_id_is_set() {
+        let (mut game, _, _, _, _, _, _) = deploy_game(0, 0, 0, 0);
+        let player1 = add_adventurer_to_game(ref game, 0, ItemId::Wand);
+        let player2 = add_adventurer_to_game(ref game, 1, ItemId::Wand);
+        let player3 = add_adventurer_to_game(ref game, 160, ItemId::Wand);
+        let player1_meta = game.get_adventurer_meta(player1);
+        let player2_meta = game.get_adventurer_meta(player2);
+        let player3_meta = game.get_adventurer_meta(player3);
+
+        assert(player1_meta.golden_token_id == 0, 'golden token id should be 0');
+        assert(player2_meta.golden_token_id == 1, 'golden token id should be 1');
+        assert(player3_meta.golden_token_id == 160, 'golden token id should be 160');
+    }
 }


### PR DESCRIPTION
- by storing client provider address we allow clients to provide onchain rewards for their players
- golden tokens are a special case because they don't pay for the game and thus don't pay the client provider
- to provide maximum flexibility for client providers, this commit adds the GT ID to adventurer metadata (0 if no GT is used).
- The above allows clients to decide whether or not to include GT games in their promotions