### PR TITLE
Fix no access to game without lords (for free games)

### DIFF
--- a/ui/src/app/components/onboarding/Login.tsx
+++ b/ui/src/app/components/onboarding/Login.tsx
@@ -10,6 +10,7 @@ import { ETH_PREFUND_AMOUNT } from "@/app/lib/constants";
 import useNetworkAccount from "@/app/hooks/useNetworkAccount";
 import { checkCartridgeConnector } from "@/app/lib/connectors";
 import { useConnect } from "@starknet-react/core";
+import { Adventurer } from "@/app/types";
 
 interface LoginProps {
   eth: number;
@@ -20,6 +21,7 @@ interface LoginProps {
   setScreen: (value: ScreenPage) => void;
   setSection: (value: Section) => void;
   getBalances: () => Promise<void>;
+  adventurers: Adventurer[];
 }
 
 const Login = ({
@@ -31,6 +33,7 @@ const Login = ({
   setScreen,
   setSection,
   getBalances,
+  adventurers,
 }: LoginProps) => {
   const { account } = useNetworkAccount();
   const [step, setStep] = useState(1);
@@ -40,12 +43,13 @@ const Login = ({
 
   const checkEnoughEth = eth >= parseInt(ETH_PREFUND_AMOUNT(network!)) - 1;
   const checkEnoughLords = lords > lordsGameCost;
+  const hasAdventurers = adventurers?.length > 0;
 
   useEffect(() => {
     if (
       account &&
       (checkEnoughEth || checkCartridgeConnector(connector)) &&
-      checkEnoughLords
+      (checkEnoughLords || hasAdventurers)
     ) {
       setScreen("start");
       handleOnboarded();
@@ -59,7 +63,7 @@ const Login = ({
     } else {
       setStep(1);
     }
-  }, [account, checkEnoughEth, checkEnoughLords]);
+  }, [account, checkEnoughEth, checkEnoughLords, hasAdventurers]);
 
   useEffect(() => {
     if (account) {

--- a/ui/src/app/components/onboarding/Sections/WalletSection.tsx
+++ b/ui/src/app/components/onboarding/Sections/WalletSection.tsx
@@ -22,7 +22,7 @@ const WalletSection = ({ step }: WalletSectionProps) => {
         <>
           <div className="absolute top-0 left-0 right-0 bottom-0 h-full w-full bg-black opacity-50 z-10" />
           {step > 1 && (
-            <div className="absolute flex flex-col w-1/2 top-1/4 right-1/4 z-20 items-center text-xl text-center">
+            <div className="absolute flex flex-col gap-5 w-1/2 top-1/4 right-1/4 z-20 items-center text-xl text-center">
               <span className="flex gap-5 items-center">
                 <p>
                   {isController ? (
@@ -37,6 +37,7 @@ const WalletSection = ({ step }: WalletSectionProps) => {
                   Copy
                 </Button>
               </span>
+              <Button onClick={() => disconnect()}>Disconnect</Button>
               <CompleteIcon />
             </div>
           )}

--- a/ui/src/app/containers/Onboarding.tsx
+++ b/ui/src/app/containers/Onboarding.tsx
@@ -7,6 +7,7 @@ import TokenLoader from "@/app/components/animations/TokenLoader";
 import Intro from "@/app/components/onboarding/Intro";
 import Login from "@/app/components/onboarding/Login";
 import InfoBox from "@/app/components/onboarding/InfoBox";
+import { Adventurer } from "@/app/types";
 
 export type Section = "connect" | "eth" | "lords" | "arcade";
 
@@ -16,6 +17,7 @@ interface OnboardingProps {
   costToPlay: bigint;
   mintLords: (lordsAmount: number) => Promise<void>;
   getBalances: () => Promise<void>;
+  adventurers: Adventurer[];
 }
 
 const Onboarding = ({
@@ -24,6 +26,7 @@ const Onboarding = ({
   costToPlay,
   mintLords,
   getBalances,
+  adventurers,
 }: OnboardingProps) => {
   const isMuted = useUIStore((state) => state.isMuted);
   const setIsMuted = useUIStore((state) => state.setIsMuted);
@@ -82,6 +85,7 @@ const Onboarding = ({
             setScreen={setScreen}
             setSection={setSection}
             getBalances={getBalances}
+            adventurers={adventurers}
           />
         )}
       </div>

--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -18,7 +18,7 @@ import useUIStore from "@/app/hooks/useUIStore";
 import useTransactionCartStore from "@/app/hooks/useTransactionCartStore";
 import { NotificationDisplay } from "@/app/components/notifications/NotificationDisplay";
 import { useMusic } from "@/app/hooks/useMusic";
-import { Menu, ZeroUpgrade, BurnerStorage, Adventurer } from "@/app/types";
+import { Menu, ZeroUpgrade, BurnerStorage } from "@/app/types";
 import { useQueriesStore } from "@/app/hooks/useQueryStore";
 import Profile from "@/app/containers/ProfileScreen";
 import { DeathDialog } from "@/app/components/adventurer/DeathDialog";
@@ -334,6 +334,8 @@ function Home() {
   const ownerVariables = useMemo(() => {
     return {
       owner: indexAddress(owner),
+      health: 0,
+      skip: 0,
     };
   }, [owner]);
 
@@ -501,16 +503,6 @@ function Home() {
   );
 
   const adventurers = adventurersData?.adventurers;
-
-  useEffect(() => {
-    if (adventurers && adventurers.length > 0) {
-      const latestAdventurer: Adventurer = adventurers[adventurers.length - 1];
-      if (latestAdventurer.health !== 0) {
-        setAdventurer(latestAdventurer);
-        handleSwitchAdventurer(latestAdventurer.id!);
-      }
-    }
-  }, [adventurers]);
 
   useEffect(() => {
     if (adventurer?.id && adventurer.health !== 0) {
@@ -695,6 +687,7 @@ function Home() {
           costToPlay={costToPlay}
           mintLords={mintLords}
           getBalances={getBalances}
+          adventurers={adventurers}
         />
       ) : (
         <>


### PR DESCRIPTION
To reconsider forcing eth and lords accrual before access, for now the below is a quick fix.

- fix fetch adventurers on page
- skip lords mint if account has adventurers