### PR TITLE
Fix storing of item specials

### DIFF
--- a/indexer/src/items.ts
+++ b/indexer/src/items.ts
@@ -300,52 +300,21 @@ export default function transform({ header, events }: Block) {
         const as = value.adventurerState;
         console.log("ITEMS_LEVELED_UP", "->", "ITEMS UPDATES");
         const result = value.items.map((item) => {
-          if (item.prefixesUnlocked && item.suffixUnlocked) {
-            return {
-              entity: {
+          return {
+            entity: {
+              item: checkExistsInt(item.itemId),
+              adventurerId: checkExistsInt(parseInt(as.adventurerId)),
+            },
+            update: {
+              $set: {
                 item: checkExistsInt(item.itemId),
                 adventurerId: checkExistsInt(parseInt(as.adventurerId)),
+                special1: checkExistsInt(item.specials.special1),
+                special2: checkExistsInt(item.specials.special2),
+                special3: checkExistsInt(item.specials.special3),
               },
-              update: {
-                $set: {
-                  item: checkExistsInt(item.itemId),
-                  adventurerId: checkExistsInt(parseInt(as.adventurerId)),
-                  special1: checkExistsInt(item.specials.special1),
-                  special2: checkExistsInt(item.specials.special2),
-                  special3: checkExistsInt(item.specials.special3),
-                },
-              },
-            };
-          } else if (item.prefixesUnlocked) {
-            return {
-              entity: {
-                item: checkExistsInt(item.itemId),
-                adventurerId: checkExistsInt(parseInt(as.adventurerId)),
-              },
-              update: {
-                $set: {
-                  item: checkExistsInt(item.itemId),
-                  adventurerId: checkExistsInt(parseInt(as.adventurerId)),
-                  special2: checkExistsInt(item.specials.special2),
-                  special3: checkExistsInt(item.specials.special3),
-                },
-              },
-            };
-          } else if (item.suffixUnlocked) {
-            return {
-              entity: {
-                item: checkExistsInt(item.itemId),
-                adventurerId: checkExistsInt(parseInt(as.adventurerId)),
-              },
-              update: {
-                $set: {
-                  item: checkExistsInt(item.itemId),
-                  adventurerId: checkExistsInt(parseInt(as.adventurerId)),
-                  special1: checkExistsInt(item.specials.special1),
-                },
-              },
-            };
-          }
+            },
+          };
         });
         const filteredResult = result.filter((value) => value !== undefined);
         return filteredResult;

--- a/ui/src/app/lib/utils/index.ts
+++ b/ui/src/app/lib/utils/index.ts
@@ -208,11 +208,11 @@ export function calculateLevel(xp: number) {
 
 export function processItemName(item: Item) {
   if (item) {
-    if (item.special2 && item.special3 && calculateLevel(item.xp ?? 0) >= 20) {
+    if (calculateLevel(item.xp ?? 0) >= 20) {
       return `${item.special2} ${item.special3} ${item.item} ${item.special1} +1`;
-    } else if (item.special2 && item.special1) {
+    } else if (calculateLevel(item.xp ?? 0) >= 19) {
       return `${item.special2} ${item.special3} ${item.item} ${item.special1}`;
-    } else if (item.special1) {
+    } else if (calculateLevel(item.xp ?? 0) >= 15) {
       return `${item.item} ${item.special1}`;
     } else {
       return `${item.item}`;

--- a/ui/src/app/lib/utils/syscalls.ts
+++ b/ui/src/app/lib/utils/syscalls.ts
@@ -571,37 +571,10 @@ export function createSyscalls({
           );
           for (let itemsLeveledUpEvent of itemsLeveledUpEvents) {
             for (let itemLeveled of itemsLeveledUpEvent.data[1]) {
-              const ownedItemIndex =
-                queryData.itemsByAdventurerQuery?.items.findIndex(
-                  (item: Item) => item.item == itemLeveled.item
-                );
               if (itemLeveled.suffixUnlocked) {
-                setData(
-                  "itemsByAdventurerQuery",
-                  itemLeveled.special1,
-                  "special1",
-                  ownedItemIndex
-                );
                 if (itemEntropy === BigInt(0)) {
                   setFetchUnlocksEntropy(true);
                 }
-              }
-              if (itemLeveled.prefixesUnlocked) {
-                setData(
-                  "itemsByAdventurerQuery",
-                  itemLeveled.special2,
-                  "special2",
-                  ownedItemIndex
-                );
-                setData(
-                  "itemsByAdventurerQuery",
-                  itemLeveled.special3,
-                  "special3",
-                  ownedItemIndex
-                );
-              }
-              if (itemLeveled.newLevel === 20) {
-                setG20Unlock(true);
               }
             }
           }


### PR DESCRIPTION
- change item names to be rendered based on item level
- update indexer to always save full specials (not dependent on unlock flags)
- remove undeeded syscalls item storage
- edit set data in queryStore to set fulll data at index

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility in setting data with optional parameters for attributes and indexes.
	- Improved item name processing based on calculated levels, affecting how items are displayed.

- **Bug Fixes**
	- Streamlined error handling and logic in data setting functions, improving robustness.

- **Refactor**
	- Simplified logic in item processing functions, reducing complexity and enhancing maintainability.

- **Chores**
	- Removed redundant code related to item leveling and unlocking, streamlining functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->