### PR TITLE
adds enter_launch_tournament_with_signature

### DIFF
--- a/contracts/game/src/game/interfaces.cairo
+++ b/contracts/game/src/game/interfaces.cairo
@@ -64,6 +64,18 @@ trait IGame<TContractState> {
         token_id: u32,
         mint_to: ContractAddress
     ) -> Array<felt252>;
+    fn enter_launch_tournament_with_signature(
+        ref self: TContractState,
+        weapon: u8,
+        name: felt252,
+        custom_renderer: ContractAddress,
+        delay_stat_reveal: bool,
+        collection_address: ContractAddress,
+        token_id: u32,
+        mint_from: ContractAddress,
+        mint_to: ContractAddress,
+        signature: Array<felt252>
+    ) -> Array<felt252>;
     fn settle_launch_tournament(ref self: TContractState);
     // ------ View Functions ------
 

--- a/contracts/game/src/game/snip12_controller_claim.cairo
+++ b/contracts/game/src/game/snip12_controller_claim.cairo
@@ -1,0 +1,73 @@
+use openzeppelin::utils::snip12::{SNIP12Metadata, StructHash};
+use core::starknet::get_tx_info;
+use core::starknet::get_caller_address;
+use core::hash::HashStateExTrait;
+use hash::{HashStateTrait, Hash};
+use poseidon::PoseidonTrait;
+use starknet::ContractAddress;
+
+const MESSAGE_TYPE_HASH: felt252 = selector!("\"Message\"(\"recipient\":\"ContractAddress\")");
+const STARKNET_DOMAIN_TYPE_HASH: felt252 =
+    0x1ff2f602e42168014d405a94f75e8a93d640751d71d16311266e140d8b0a210;
+
+#[derive(Hash, Drop, Copy)]
+struct StarknetDomain {
+    name: felt252,
+    version: felt252,
+    chain_id: felt252,
+    revision: felt252,
+}
+
+impl StructHashStarknetDomainImpl of StructHash<StarknetDomain> {
+    fn hash_struct(self: @StarknetDomain) -> felt252 {
+        let hash_state = PoseidonTrait::new();
+        hash_state.update_with(STARKNET_DOMAIN_TYPE_HASH).update_with(*self).finalize()
+    }
+}
+
+#[derive(Copy, Drop, Hash)]
+struct Message {
+    recipient: ContractAddress,
+}
+
+impl StructHashImpl of StructHash<Message> {
+    fn hash_struct(self: @Message) -> felt252 {
+        let hash_state = PoseidonTrait::new();
+        hash_state.update_with(MESSAGE_TYPE_HASH).update_with(*self).finalize()
+    }
+}
+
+pub trait OffchainMessageHash<T> {
+    fn get_message_hash(self: @T, signer: ContractAddress) -> felt252;
+}
+
+impl OffchainMessageHashImpl of OffchainMessageHash<Message> {
+    fn get_message_hash(self: @Message, signer: ContractAddress) -> felt252 {
+        let domain = StarknetDomain {
+            name: 'Loot Survivor',
+            version: '1',
+            chain_id: get_tx_info().unbox().chain_id,
+            revision: 1
+        };
+        let mut state = PoseidonTrait::new();
+        state = state.update_with('StarkNet Message');
+        state = state.update_with(domain.hash_struct());
+        state = state.update_with(signer);
+        state = state.update_with(self.hash_struct());
+        state.finalize()
+    }
+}
+
+impl SNIP12MetadataImpl of SNIP12Metadata {
+    fn name() -> felt252 {
+        'Loot_Survivor'
+    }
+    fn version() -> felt252 {
+        'v1'
+    }
+}
+
+fn get_hash(account: ContractAddress, recipient: ContractAddress,) -> felt252 {
+    let message = Message { recipient };
+    message.get_message_hash(account)
+}


### PR DESCRIPTION
- this allows new controller account to claim qualifying NFTs from an external account, without requiring that account to sign an onchain tx
- this allows blank argent/braavos accounts receiving the Syndicate airdrop to be onboarded without having to bridge any funds to SN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new function for entering tournaments with additional parameters, enhancing user experience.
	- Added functionality for secure off-chain message hashing, improving interaction within the ecosystem.
	- Enhanced NFT ownership verification during tournament entries for increased security.

- **Bug Fixes**
	- Refactored existing tournament entry function to ensure proper signature verification and ownership checks.

- **Documentation**
	- Updated comments and documentation to clarify new parameters and their implications for gameplay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->