### PR TITLE
Add item swap warnings

### DIFF
--- a/ui/src/app/components/adventurer/BeastSwapWarning.tsx
+++ b/ui/src/app/components/adventurer/BeastSwapWarning.tsx
@@ -11,7 +11,7 @@ export const BeastSwapWarning = ({
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
       <div className="bg-terminal-black border border-terminal-green p-4 max-w-md w-full">
         <div className="mb-4">
-          <h1 className="text-xl font-bold uppercase">Beast Attack Warming</h1>
+          <h1 className="text-xl font-bold uppercase">Beast Attack Warning</h1>
         </div>
         <p className="mb-2">
           Swapping an item during a beast battle will result in a beast counter

--- a/ui/src/app/components/adventurer/BeastSwapWarning.tsx
+++ b/ui/src/app/components/adventurer/BeastSwapWarning.tsx
@@ -1,0 +1,29 @@
+import { Button } from "@/app/components/buttons/Button";
+
+interface BeastSwapWarningProps {
+  handleConfirmAction: () => void;
+}
+
+export const BeastSwapWarning = ({
+  handleConfirmAction,
+}: BeastSwapWarningProps) => {
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-terminal-black border border-terminal-green p-4 max-w-md w-full">
+        <div className="mb-4">
+          <h1 className="text-xl font-bold uppercase">Beast Attack Warming</h1>
+        </div>
+        <p className="mb-2">
+          Swapping an item during a beast battle will result in a beast counter
+          attack.
+        </p>
+        <p className="mb-2 uppercase">
+          Swap multiple items together to avoid multiple attacks.
+        </p>
+        <div className="flex justify-end gap-2">
+          <Button onClick={handleConfirmAction}>Confirm</Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/ui/src/app/components/adventurer/Player.tsx
+++ b/ui/src/app/components/adventurer/Player.tsx
@@ -1,6 +1,9 @@
-import { Contract } from "starknet";
+import { BeastSwapWarning } from "@/app/components/adventurer/BeastSwapWarning";
 import Info from "@/app/components/adventurer/Info";
 import useAdventurerStore from "@/app/hooks/useAdventurerStore";
+import useUIStore from "@/app/hooks/useUIStore";
+import { useEffect, useState } from "react";
+import { Contract } from "starknet";
 
 interface PlayerProps {
   gameContract: Contract;
@@ -8,8 +11,26 @@ interface PlayerProps {
 
 export default function Player({ gameContract }: PlayerProps) {
   const adventurer = useAdventurerStore((state) => state.adventurer);
+  const equipItems = useUIStore((state) => state.equipItems);
+  const hasBeast = useAdventurerStore((state) => state.computed.hasBeast);
+
+  const [beastSwapWarning, setBeastSwapWarning] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (equipItems.length > 0 && hasBeast) {
+      setBeastSwapWarning(true);
+    }
+  }, [equipItems]);
+
   return (
     <>
+      {beastSwapWarning && (
+        <BeastSwapWarning
+          handleConfirmAction={() => {
+            setBeastSwapWarning(false);
+          }}
+        />
+      )}
       {adventurer?.id ? (
         <Info adventurer={adventurer} gameContract={gameContract} />
       ) : (

--- a/ui/src/app/components/adventurer/StatRemovalWarning.tsx
+++ b/ui/src/app/components/adventurer/StatRemovalWarning.tsx
@@ -1,0 +1,43 @@
+import { Button } from "@/app/components/buttons/Button";
+
+interface StatRemovalWarningProps {
+  statWarning: "charisma" | "vitality";
+  handleConfirmAction: () => void;
+}
+
+export const StatRemovalWarning = ({
+  statWarning,
+  handleConfirmAction,
+}: StatRemovalWarningProps) => {
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-terminal-black border border-terminal-green p-4 max-w-md w-full">
+        <div className="mb-4">
+          <h1 className="text-xl font-bold uppercase">
+            {statWarning} Removal Warning
+          </h1>
+        </div>
+        {statWarning === "vitality" ? (
+          <>
+            <p className="mb-2">
+              Removing vitality will reduce your max health by 15hp per vitality
+              removed.
+            </p>
+            <p className="mb-2 uppercase">
+              If your current health is larger than the new calculated max
+              health, it will be lost and cannot be recovered.
+            </p>
+          </>
+        ) : (
+          <p className="mb-2">
+            Removing charisma will reduce your max health by 15hp per vitality
+            removed.
+          </p>
+        )}
+        <div className="flex justify-end gap-2">
+          <Button onClick={handleConfirmAction}>Confirm</Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/ui/src/app/components/adventurer/StatRemovalWarning.tsx
+++ b/ui/src/app/components/adventurer/StatRemovalWarning.tsx
@@ -20,7 +20,7 @@ export const StatRemovalWarning = ({
         {statWarning === "vitality" ? (
           <>
             <p className="mb-2">
-              Removing vitality will reduce your max health by 15hp per vitality
+              Removing vitality will reduce your max health by 15hp per point
               removed.
             </p>
             <p className="mb-2 uppercase">
@@ -30,7 +30,7 @@ export const StatRemovalWarning = ({
           </>
         ) : (
           <p className="mb-2">
-            Removing charisma will reduce your max health by 15hp per vitality
+            Removing charisma will increase market prices by 1 gold per point
             removed.
           </p>
         )}

--- a/ui/src/app/containers/BeastScreen.tsx
+++ b/ui/src/app/containers/BeastScreen.tsx
@@ -1,31 +1,32 @@
-import React, { useState, useEffect } from "react";
-import { Contract } from "starknet";
+import { BeastSwapWarning } from "@/app/components/adventurer/BeastSwapWarning";
+import { BattleDialog } from "@/app/components/BattleDialog";
 import { BattleDisplay } from "@/app/components/beast/BattleDisplay";
 import { BeastDisplay } from "@/app/components/beast/BeastDisplay";
-import useLoadingStore from "@/app/hooks/useLoadingStore";
-import useAdventurerStore from "@/app/hooks/useAdventurerStore";
-import { useQueriesStore } from "@/app/hooks/useQueryStore";
-import { processBeastName, getItemData, getBeastData } from "@/app/lib/utils";
-import { Battle, NullBeast, ButtonData, Beast } from "@/app/types";
 import { Button } from "@/app/components/buttons/Button";
-import useUIStore from "@/app/hooks/useUIStore";
+import { FleeDialog } from "@/app/components/FleeDialog";
+import {
+  CompleteIcon,
+  GiBattleGearIcon,
+  HeartIcon,
+  SkullCrossedBonesIcon,
+} from "@/app/components/icons/Icons";
 import ActionMenu from "@/app/components/menu/ActionMenu";
 import { useController } from "@/app/context/ControllerContext";
+import useAdventurerStore from "@/app/hooks/useAdventurerStore";
+import useLoadingStore from "@/app/hooks/useLoadingStore";
+import { useQueriesStore } from "@/app/hooks/useQueryStore";
+import { soundSelector, useUiSounds } from "@/app/hooks/useUiSound";
+import useUIStore from "@/app/hooks/useUIStore";
+import { getBeastData, getItemData, processBeastName } from "@/app/lib/utils";
 import {
   getGoldReward,
   nextAttackResult,
   simulateBattle,
   simulateFlee,
 } from "@/app/lib/utils/processFutures";
-import {
-  GiBattleGearIcon,
-  HeartIcon,
-  SkullCrossedBonesIcon,
-  CompleteIcon,
-} from "@/app/components/icons/Icons";
-import { FleeDialog } from "@/app/components/FleeDialog";
-import { BattleDialog } from "@/app/components/BattleDialog";
-import { useUiSounds, soundSelector } from "@/app/hooks/useUiSound";
+import { Battle, Beast, ButtonData, NullBeast } from "@/app/types";
+import React, { useEffect, useState } from "react";
+import { Contract } from "starknet";
 
 interface BeastScreenProps {
   attack: (
@@ -56,6 +57,7 @@ export default function BeastScreen({
   const showFleeDialog = useUIStore((state) => state.showFleeDialog);
   const tillDeath = useUIStore((state) => state.tillDeath);
   const setTillDeath = useUIStore((state) => state.setTillDeath);
+  const equipItems = useUIStore((state) => state.equipItems);
   const resetNotification = useLoadingStore((state) => state.resetNotification);
   const [showBattleLog, setShowBattleLog] = useState(false);
   const [showFutures, setShowFutures] = useState(false);
@@ -67,6 +69,7 @@ export default function BeastScreen({
   const formatBattles = useQueriesStore(
     (state) => state.data.battlesByBeastQuery?.battles || []
   );
+  const [beastSwapWarning, setBeastSwapWarning] = useState<boolean>(false);
 
   const { play: clickPlay } = useUiSounds(soundSelector.click);
 
@@ -237,12 +240,25 @@ export default function BeastScreen({
     </div>
   );
 
+  useEffect(() => {
+    if (equipItems.length > 0 && hasBeast) {
+      setBeastSwapWarning(true);
+    }
+  }, [equipItems]);
+
   if (showBattleLog) {
     return <BattleLog />;
   }
 
   return (
     <div className="sm:w-2/3 flex flex-col sm:flex-row h-full">
+      {beastSwapWarning && (
+        <BeastSwapWarning
+          handleConfirmAction={() => {
+            setBeastSwapWarning(false);
+          }}
+        />
+      )}
       <div className="sm:w-1/2 order-1 sm:order-2 h-3/4 sm:h-full">
         {hasBeast ? (
           <BeastDisplay beastData={beastData} beastsContract={beastsContract} />

--- a/ui/src/app/containers/ProfileScreen.tsx
+++ b/ui/src/app/containers/ProfileScreen.tsx
@@ -1,11 +1,11 @@
+import Info from "@/app/components/adventurer/Info";
+import { Button } from "@/app/components/buttons/Button";
+import EncountersScreen from "@/app/containers/EncountersScreen";
+import { useQueriesStore } from "@/app/hooks/useQueryStore";
+import useUIStore from "@/app/hooks/useUIStore";
+import { NullAdventurer } from "@/app/types";
 import { useState } from "react";
 import { Contract } from "starknet";
-import Info from "@/app/components/adventurer/Info";
-import { useQueriesStore } from "@/app/hooks/useQueryStore";
-import { Button } from "@/app/components/buttons/Button";
-import useUIStore from "@/app/hooks/useUIStore";
-import EncountersScreen from "@/app/containers/EncountersScreen";
-import { NullAdventurer } from "@/app/types";
 
 interface ProfileProps {
   gameContract: Contract;

--- a/ui/src/app/containers/UpgradeScreen.tsx
+++ b/ui/src/app/containers/UpgradeScreen.tsx
@@ -23,8 +23,6 @@ import useUIStore from "@/app/hooks/useUIStore";
 import { vitalityIncrease } from "@/app/lib/constants";
 import { GameData } from "@/app/lib/data/GameData";
 import {
-  calculateChaBoostRemoved,
-  calculateVitBoostRemoved,
   getItemData,
   getItemPrice,
   getPotionPrice,
@@ -80,14 +78,11 @@ export default function UpgradeScreen({
   const setUpgrades = useUIStore((state) => state.setUpgrades);
   const purchaseItems = useUIStore((state) => state.purchaseItems);
   const setPurchaseItems = useUIStore((state) => state.setPurchaseItems);
-  const equipItems = useUIStore((state) => state.equipItems);
   const dropItems = useUIStore((state) => state.dropItems);
   const entropyReady = useUIStore((state) => state.entropyReady);
   const onKatana = useUIStore((state) => state.onKatana);
   const chaBoostRemoved = useUIStore((state) => state.chaBoostRemoved);
   const vitBoostRemoved = useUIStore((state) => state.vitBoostRemoved);
-  const setVitBoostRemoved = useUIStore((state) => state.setVitBoostRemoved);
-  const setChaBoostRemoved = useUIStore((state) => state.setChaBoostRemoved);
   const pendingMessage = useLoadingStore((state) => state.pendingMessage);
   const [summary, setSummary] = useState<UpgradeSummary>({
     Stats: { ...ZeroUpgrade },
@@ -236,26 +231,6 @@ export default function UpgradeScreen({
   const adventurerItems = useQueriesStore(
     (state) => state.data.itemsByAdventurerQuery?.items || []
   );
-
-  useEffect(() => {
-    const chaBoostRemoved = calculateChaBoostRemoved(
-      purchaseItems,
-      adventurer!,
-      adventurerItems,
-      equipItems,
-      dropItems
-    );
-    setChaBoostRemoved(chaBoostRemoved);
-
-    const vitBoostRemoved = calculateVitBoostRemoved(
-      purchaseItems,
-      adventurer!,
-      adventurerItems,
-      equipItems,
-      dropItems
-    );
-    setVitBoostRemoved(vitBoostRemoved);
-  }, [purchaseItems, adventurer, adventurerItems, equipItems, dropItems]);
 
   useEffect(() => {
     setTotalVitality((adventurer?.vitality ?? 0) + selectedVitality);

--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -56,7 +56,12 @@ import { checkArcadeConnector } from "@/app/lib/connectors";
 import { VRF_WAIT_TIME } from "@/app/lib/constants";
 import { networkConfig } from "@/app/lib/networkConfig";
 import Storage from "@/app/lib/storage";
-import { indexAddress, padAddress } from "@/app/lib/utils";
+import {
+  calculateChaBoostRemoved,
+  calculateVitBoostRemoved,
+  indexAddress,
+  padAddress,
+} from "@/app/lib/utils";
 import { useSyscalls } from "@/app/lib/utils/syscalls";
 import { BurnerStorage, Menu, ZeroUpgrade } from "@/app/types";
 import { useQuery } from "@apollo/client";
@@ -65,6 +70,7 @@ import { sepolia } from "@starknet-react/chains";
 import { useConnect, useContract, useProvider } from "@starknet-react/core";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { constants } from "starknet";
+import { StatRemovalWarning } from "./components/adventurer/StatRemovalWarning";
 import CollectionsLeaderboardScreen from "./containers/CollectionsLeaderboardScreen";
 import Onboarding from "./containers/Onboarding";
 
@@ -735,6 +741,49 @@ function Home() {
     fetchFreeVRF();
   }, []);
 
+  const vitBoostRemoved = useUIStore((state) => state.vitBoostRemoved);
+  const setVitBoostRemoved = useUIStore((state) => state.setVitBoostRemoved);
+  const chaBoostRemoved = useUIStore((state) => state.chaBoostRemoved);
+  const setChaBoostRemoved = useUIStore((state) => state.setChaBoostRemoved);
+  const purchaseItems = useUIStore((state) => state.purchaseItems);
+  const equipItems = useUIStore((state) => state.equipItems);
+  const dropItems = useUIStore((state) => state.dropItems);
+  const adventurerItems = useQueriesStore(
+    (state) => state.data.itemsByAdventurerQuery?.items || []
+  );
+
+  const [statRemovalWarning, setStatRemovalWarning] = useState<
+    "vitality" | "charisma" | ""
+  >("");
+
+  useEffect(() => {
+    const chaBoostRemoved = calculateChaBoostRemoved(
+      purchaseItems,
+      adventurer!,
+      adventurerItems,
+      equipItems,
+      dropItems
+    );
+    setChaBoostRemoved(chaBoostRemoved);
+
+    const vitBoostRemoved = calculateVitBoostRemoved(
+      purchaseItems,
+      adventurer!,
+      adventurerItems,
+      equipItems,
+      dropItems
+    );
+    setVitBoostRemoved(vitBoostRemoved);
+  }, [purchaseItems, adventurer, adventurerItems, equipItems, dropItems]);
+
+  useEffect(() => {
+    if (vitBoostRemoved > 0) {
+      setStatRemovalWarning("vitality");
+    } else if (chaBoostRemoved > 0) {
+      setStatRemovalWarning("charisma");
+    }
+  }, [vitBoostRemoved, chaBoostRemoved]);
+
   return (
     <>
       {openInterlude && !onKatana && (
@@ -768,6 +817,14 @@ function Home() {
                 lordsContract={lordsContract!}
                 ethContract={ethContract!}
                 showTopUpDialog={showTopUpDialog}
+              />
+            )}
+            {statRemovalWarning && (
+              <StatRemovalWarning
+                statWarning={statRemovalWarning}
+                handleConfirmAction={() => {
+                  setStatRemovalWarning("");
+                }}
               />
             )}
             {!spawnLoader && hash && (


### PR DESCRIPTION
- add vitality and charisma item swap warnings
- add swap warning when in a beast battle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced `BeastSwapWarning` component to alert users about item swapping consequences during beast battles.
	- Added `StatRemovalWarning` component to inform users about the implications of removing character stats like vitality and charisma.
	- Enhanced `BeastScreen` with a warning dialog for item management when a beast is equipped.
	- Updated `Player` component to manage warnings related to beast swapping.
	- Improved `page` to provide real-time feedback on character stat changes, displaying warnings when necessary.

- **Bug Fixes**
	- Streamlined state management in `UpgradeScreen`, removing unnecessary calculations related to charisma and vitality boosts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->